### PR TITLE
FEAT : accessToken 쿠키 및 헤더에 추가로 변경,refresh 토큰 생성, 카카오 로그인으로 유저정보 가져오기

### DIFF
--- a/nawabali/build.gradle
+++ b/nawabali/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/nawabali/src/main/java/com/nawabali/nawabali/config/RestTemplateConfig.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.nawabali.nawabali.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig  {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+                // 무한 대기 상태 방지를 위해 강제 종료 설정
+                .setConnectTimeout(Duration.ofSeconds(5)) // 5초
+                .setReadTimeout(Duration.ofSeconds(5)) // 5초
+                .build();
+    }
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/config/WebSecurityConfig.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/config/WebSecurityConfig.java
@@ -59,6 +59,8 @@ public class WebSecurityConfig {
                         .requestMatchers("/users/login").permitAll()
                         .requestMatchers("/posts").permitAll()
                         .requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 게시글 상세 조회 허가
+                        .requestMatchers("/users/test").permitAll()
+                        .requestMatchers("/users/kakao/callback").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -1,19 +1,22 @@
 package com.nawabali.nawabali.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nawabali.nawabali.dto.SignupDto;
+import com.nawabali.nawabali.service.KakaoService;
 import com.nawabali.nawabali.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-@RestController
+@Controller
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
-//    private final KakaoService kakaoService;
+    private final KakaoService kakaoService;
 
     @PostMapping("/signup")
     public SignupDto.SignupResponseDto signup(@RequestBody SignupDto.SignupRequestDto requestDto) {
@@ -21,7 +24,13 @@ public class UserController {
     }
 
     @GetMapping("/kakao/callback")
-    public void kakaoLogin(@RequestParam String code, HttpServletResponse res) {
-//        kakaoService.login(code, res);}
+    public String kakaoLogin(@RequestParam String code, HttpServletResponse res) throws JsonProcessingException {
+        kakaoService.kakaoLogin(code, res);
+        return "redirect:/users/test";
+    }
+
+    @GetMapping("/test")
+    public String test(){
+        return "login";
     }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
@@ -29,4 +29,15 @@ public class User {
         this.password = password;
         this.role = role;
     }
+
+    @Builder
+    public User(String nickname, String email, Long kakaoId){
+        this.nickname = nickname;
+        this.email = email;
+        this.kakaoId = kakaoId;
+    }
+
+    public void updateKakaoId(Long id) {
+        this.kakaoId = id;
+    }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/UserDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/UserDto.java
@@ -9,4 +9,18 @@ public class UserDto {
         String email;
         String password;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoUserInfoDto{
+        Long id;
+        String email;
+        String nickname;
+
+        public KakaoUserInfoDto(Long id, String nickname, String email) {
+            this.id = id;
+            this.nickname = nickname;
+            this.email = email;
+        }
+    }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/UserRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByEmail(String email);
 
     boolean existsByEmail(String toEmail);
+
+    User findByKakaoId(Long id);
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/security/Jwt/JwtUtil.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/security/Jwt/JwtUtil.java
@@ -40,8 +40,8 @@ public class JwtUtil {
     // 로그 설정
     public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
     // 토큰 만료 시간
-    private final int ACCESS_EXPIRATION_TIME = 600000; //10분
-    public final int REFRESH_EXPIRATION_TIME = 600000 * 3; // 30분
+    private final int ACCESS_EXPIRATION_TIME = 24 * 60 * 60 * 1000; //
+    public final int REFRESH_EXPIRATION_TIME = 30 * 60 * 1000; // 30분
     @PostConstruct
     public void init() {
         byte[] bytes = Base64.getDecoder().decode(secretKey);
@@ -64,32 +64,32 @@ public class JwtUtil {
     }
 
     // 리프레시 토큰 생성
-//    public String createRefreshToken(String email) {
-//        Date now = new Date();
-//        Date expireDate = new Date(now.getTime() + REFRESH_EXPIRATION_TIME);
-//
-//        return Jwts.builder()
-//                .setSubject(email)
-//                .setExpiration(expireDate)
-//                .setIssuedAt(now)
-//                .signWith(key, signatureAlgorithm)
-//                .compact();
-//    }
+    public String createRefreshToken(String email) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + REFRESH_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setExpiration(expireDate)
+                .setIssuedAt(now)
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
 
     // 쿠키(리프레시) 생성
-//    public Cookie createCookie(String email) {
-//        String cookieValue = createRefreshToken(email);
-//        var refreshTokenCookie = URLEncoder.encode(cookieValue, UTF_8);
-//        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshTokenCookie);
-//        cookie.setHttpOnly(true);
-//        // cookie.setSecure(true); //Https 접근이 아직 활성화 안됨. 활성화되면 바꿔주기
-//        cookie.setPath("/");
-//        cookie.setMaxAge(REFRESH_EXPIRATION_TIME);
-//        return cookie;
-//    }
+    public Cookie createRefreshCookie(String email) {
+        String cookieValue = createRefreshToken(email);
+        var refreshTokenCookie = URLEncoder.encode(cookieValue, UTF_8);
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshTokenCookie);
+        cookie.setHttpOnly(true);
+        // cookie.setSecure(true); //Https 접근이 아직 활성화 안됨. 활성화되면 바꿔주기
+        cookie.setPath("/");
+        cookie.setMaxAge(REFRESH_EXPIRATION_TIME);
+        return cookie;
+    }
     // 쿠키(엑세스) 생성
-    public Cookie createCookie(String email, UserRoleEnum role) {
-        String cookieValue = createAccessToken(email,role);
+    public Cookie createAccessCookie(String email, UserRoleEnum role) {
+        String cookieValue = createAccessToken(email, role);
         var accessTokenCookie = URLEncoder.encode(cookieValue, UTF_8);
         Cookie cookie = new Cookie(AUTHORIZATION_HEADER, accessTokenCookie);
         cookie.setPath("/");
@@ -108,6 +108,7 @@ public class JwtUtil {
 
     // 토큰 검증
     public boolean validateToken(String token) {
+        log.info("토큰 검증");
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;

--- a/nawabali/src/main/java/com/nawabali/nawabali/service/KakaoService.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/service/KakaoService.java
@@ -1,0 +1,158 @@
+package com.nawabali.nawabali.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nawabali.nawabali.domain.User;
+import com.nawabali.nawabali.dto.UserDto;
+import com.nawabali.nawabali.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Slf4j(topic = "카카오 로그인")
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+    private final RestTemplate restTemplate;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void kakaoLogin(String code, HttpServletResponse res) throws JsonProcessingException {
+        // 1. 인가 코드로 엑세스 토큰 요청
+        String accessToken = getToken(code);
+
+        // 2. 엑세스 토큰으로 사용자 정보 가져오기
+        UserDto.KakaoUserInfoDto kakaoUserInfoDto = getKakaoUserInfo(accessToken);
+
+        // 3. 필요시에 회원가입
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfoDto);
+    }
+
+
+    private String getToken(String code) throws JsonProcessingException {
+        log.info("인가코드로 엑세스 토큰 요청. 인가코드 : " + code);
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "f7dda01bb0485f7f9b1a92a21952688e");
+        body.add("redirect_uri", "http://localhost:8080/users/kakao/callback");
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        String token = jsonNode.get("access_token").asText();
+        log.info("kakaoAccessToken: " + token);
+        return token;
+    }
+    private UserDto.KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        log.info("카카오 사용자 정보 불러오기");
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        System.out.println("id = " + id);
+
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        System.out.println("nickname = " + nickname);
+
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+//        System.out.println("email = " + email);
+        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " );
+        return new UserDto.KakaoUserInfoDto(id, nickname, email);
+    }
+
+    private User registerKakaoUserIfNeeded(UserDto.KakaoUserInfoDto kakaoUserInfoDto) {
+        // DB에 기존 카카오 유저 확인
+        Long id = kakaoUserInfoDto.getId();
+        User kakaoUser = userRepository.findByKakaoId(id);
+        if(kakaoUser==null){
+            // 카카오 사용자 email 과 동일한 email 있는지 확인
+            // 있다면 카카오아이디 업데이트
+            String kakaoEmail = kakaoUser.getEmail();
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail);
+            if(sameEmailUser != null){
+                kakaoUser = sameEmailUser;
+                kakaoUser.updateKakaoId(id);
+
+            } else{
+                // 신규 회원가입
+                // password: random UUID
+                String password = UUID.randomUUID().toString();
+                String encodedPassword = passwordEncoder.encode(password);
+
+                // email : kakao-email
+                String email = kakaoUserInfoDto.getEmail();
+                String nickName = kakaoUserInfoDto.getNickname();
+                kakaoUser = User.builder()
+                        .nickname(nickName)
+                        .email(email)
+                        .password(encodedPassword)
+                        .build();
+            }
+            userRepository.save(kakaoUser);
+        }
+        return kakaoUser;
+    }
+
+
+}

--- a/nawabali/src/main/resources/templates/login.html
+++ b/nawabali/src/main/resources/templates/login.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"
+            integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"></script>
+    <meta charset="UTF-8">
+    <title>로그인 페이지</title>
+</head>
+<body>
+<div id="login-form">
+    <div id="login-title">Log into Select Shop</div>
+    <button id="login-kakao-btn" onclick="location.href='https://kauth.kakao.com/oauth/authorize?client_id=f7dda01bb0485f7f9b1a92a21952688e&redirect_uri=http://localhost:8080/users/kakao/callback&response_type=code'">
+        카카오로 로그인하기
+    </button>
+    <button id="login-id-btn" onclick="location.href='/api/user/signup'">
+        회원 가입하기
+    </button>
+    <div>
+        <div class="login-id-label">아이디</div>
+        <input type="text" name="username" id="username" class="login-input-box">
+
+        <div class="login-id-label">비밀번호</div>
+        <input type="password" name="password" id="password" class="login-input-box">
+
+        <button id="login-id-submit" onclick="onLogin()">로그인</button>
+    </div>
+    <div id="login-failed" style="display:none" class="alert alert-danger" role="alert">로그인에 실패하였습니다.</div>
+</div>
+</body>
+<script>
+    $(document).ready(function () {
+        // 토큰 삭제
+        Cookies.remove('Authorization', {path: '/'});
+    });
+
+    const href = location.href;
+    const queryString = href.substring(href.indexOf("?") + 1)
+    if (queryString === 'error') {
+        const errorDiv = document.getElementById('login-failed');
+        errorDiv.style.display = 'block';
+    }
+
+    const host = 'http://' + window.location.host;
+
+    function onLogin() {
+        let username = $('#username').val();
+        let password = $('#password').val();
+
+        $.ajax({
+            type: "POST",
+            url: `/api/user/login`,
+            contentType: "application/json",
+            data: JSON.stringify({username: username, password: password}),
+        })
+            .done(function (res, status, xhr) {
+                const token = xhr.getResponseHeader('Authorization');
+
+                Cookies.set('Authorization', token, {path: '/'})
+
+                $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+                    jqXHR.setRequestHeader('Authorization', token);
+                });
+
+                window.location.href = host;
+            })
+            .fail(function (jqXHR, textStatus) {
+                alert("Login Fail");
+                window.location.href = host + '/api/user/login-page?error'
+            });
+    }
+</script>
+</html>


### PR DESCRIPTION
아래는 나래님과 말씀 나눈 내용입니다.
"refresh토큰을 쿠키에 저장. 로그인 후 header에 accessToken을 보내주면 cookie로에 accessToken을 넣어서 보내주는 방식으로 진행."
refresh는 추후 구현을 해도 되기 때문에 인증, 인가가 필요하여 accessToken만 구현하여 요청 보냅니다. 참고하여 아래 내용을 읽어주세요.

accessToken 쿠키 및 헤더에 추가
- Postman으로 작업시 cookie에 token값이 추가되어 인증,인가에 문제가 없을 것으로 예상.
- 헤더에 추가하는 이유는 front에 전달하기 위함. cookie에 토큰을 AuthenticationPrincipal에서 유저정보를 가져올 수 있음.

refresh 토큰 생성
- refresh토큰으로 인증,인가에 대한 공부가 필요함.
- refresh토큰을 생성하여 로그에 띄우는 부분만 구현

카카오 엑세스 토큰으로 유저정보 가져오기
- 유저정보를 가져오면서 email값을 null로 가져오는 문제 발생.  카카오 계정 2차인증을 하지 않아서 예상됨. 추후 확인 예정.