### PR TITLE
Feat : 게시물 전체 조회 시 무한 스크롤 구현

### DIFF
--- a/nawabali/build.gradle
+++ b/nawabali/build.gradle
@@ -22,6 +22,11 @@ repositories {
 }
 
 dependencies {
+	// Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	// aws s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
@@ -50,6 +55,24 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/nawabali/src/main/generated/com/nawabali/nawabali/constant/QAddress.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/constant/QAddress.java
@@ -1,0 +1,39 @@
+package com.nawabali.nawabali.constant;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAddress is a Querydsl query type for Address
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAddress extends BeanPath<Address> {
+
+    private static final long serialVersionUID = 458720951L;
+
+    public static final QAddress address = new QAddress("address");
+
+    public final StringPath city = createString("city");
+
+    public final StringPath district = createString("district");
+
+    public QAddress(String variable) {
+        super(Address.class, forVariable(variable));
+    }
+
+    public QAddress(Path<? extends Address> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAddress(PathMetadata metadata) {
+        super(Address.class, metadata);
+    }
+
+}
+

--- a/nawabali/src/main/generated/com/nawabali/nawabali/constant/QTown.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/constant/QTown.java
@@ -1,0 +1,39 @@
+package com.nawabali.nawabali.constant;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTown is a Querydsl query type for Town
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QTown extends BeanPath<Town> {
+
+    private static final long serialVersionUID = 266153647L;
+
+    public static final QTown town = new QTown("town");
+
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
+    public QTown(String variable) {
+        super(Town.class, forVariable(variable));
+    }
+
+    public QTown(Path<? extends Town> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTown(PathMetadata metadata) {
+        super(Town.class, metadata);
+    }
+
+}
+

--- a/nawabali/src/main/generated/com/nawabali/nawabali/domain/QPost.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/domain/QPost.java
@@ -1,0 +1,66 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPost is a Querydsl query type for Post
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPost extends EntityPathBase<Post> {
+
+    private static final long serialVersionUID = 928219229L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPost post = new QPost("post");
+
+    public final EnumPath<com.nawabali.nawabali.constant.Category> category = createEnum("category", com.nawabali.nawabali.constant.Category.class);
+
+    public final StringPath contents = createString("contents");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<com.nawabali.nawabali.domain.image.PostImage, com.nawabali.nawabali.domain.image.QPostImage> images = this.<com.nawabali.nawabali.domain.image.PostImage, com.nawabali.nawabali.domain.image.QPostImage>createList("images", com.nawabali.nawabali.domain.image.PostImage.class, com.nawabali.nawabali.domain.image.QPostImage.class, PathInits.DIRECT2);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public final StringPath title = createString("title");
+
+    public final com.nawabali.nawabali.constant.QTown town;
+
+    public final QUser user;
+
+    public QPost(String variable) {
+        this(Post.class, forVariable(variable), INITS);
+    }
+
+    public QPost(Path<? extends Post> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPost(PathMetadata metadata, PathInits inits) {
+        this(Post.class, metadata, inits);
+    }
+
+    public QPost(Class<? extends Post> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.town = inits.isInitialized("town") ? new com.nawabali.nawabali.constant.QTown(forProperty("town")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/nawabali/src/main/generated/com/nawabali/nawabali/domain/QTimeStamp.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/domain/QTimeStamp.java
@@ -1,0 +1,39 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTimeStamp is a Querydsl query type for TimeStamp
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QTimeStamp extends EntityPathBase<TimeStamp> {
+
+    private static final long serialVersionUID = -14442663L;
+
+    public static final QTimeStamp timeStamp = new QTimeStamp("timeStamp");
+
+    public final DateTimePath<java.time.LocalDateTime> createAt = createDateTime("createAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public QTimeStamp(String variable) {
+        super(TimeStamp.class, forVariable(variable));
+    }
+
+    public QTimeStamp(Path<? extends TimeStamp> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTimeStamp(PathMetadata metadata) {
+        super(TimeStamp.class, metadata);
+    }
+
+}
+

--- a/nawabali/src/main/generated/com/nawabali/nawabali/domain/QUser.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/domain/QUser.java
@@ -1,0 +1,63 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 928371592L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUser user = new QUser("user");
+
+    public final com.nawabali.nawabali.constant.QAddress address;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> kakaoId = createNumber("kakaoId", Long.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final EnumPath<com.nawabali.nawabali.constant.UserRoleEnum> role = createEnum("role", com.nawabali.nawabali.constant.UserRoleEnum.class);
+
+    public final StringPath username = createString("username");
+
+    public QUser(String variable) {
+        this(User.class, forVariable(variable), INITS);
+    }
+
+    public QUser(Path<? extends User> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUser(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new com.nawabali.nawabali.constant.QAddress(forProperty("address")) : null;
+    }
+
+}
+

--- a/nawabali/src/main/generated/com/nawabali/nawabali/domain/image/QPostImage.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/domain/image/QPostImage.java
@@ -1,0 +1,55 @@
+package com.nawabali.nawabali.domain.image;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPostImage is a Querydsl query type for PostImage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPostImage extends EntityPathBase<PostImage> {
+
+    private static final long serialVersionUID = 260309995L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPostImage postImage = new QPostImage("postImage");
+
+    public final StringPath fileName = createString("fileName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imgUrl = createString("imgUrl");
+
+    public final com.nawabali.nawabali.domain.QPost post;
+
+    public QPostImage(String variable) {
+        this(PostImage.class, forVariable(variable), INITS);
+    }
+
+    public QPostImage(Path<? extends PostImage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPostImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPostImage(PathMetadata metadata, PathInits inits) {
+        this(PostImage.class, metadata, inits);
+    }
+
+    public QPostImage(Class<? extends PostImage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new com.nawabali.nawabali.domain.QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/nawabali/src/main/java/com/nawabali/nawabali/config/WebSecurityConfig.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/config/WebSecurityConfig.java
@@ -60,7 +60,7 @@ public class WebSecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
                         .requestMatchers("/users/signup").permitAll()
-                        .requestMatchers("/users/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/users/login").permitAll()
                         .requestMatchers("/posts").permitAll()
                         .requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 게시글 상세 조회 허가
                         .requestMatchers("/users/test").permitAll()

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -7,6 +7,10 @@ import com.nawabali.nawabali.service.PostService;
 import jakarta.mail.Multipart;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -31,6 +35,16 @@ public class PostController {
     }
 
 
+    @GetMapping("/latest")
+    public ResponseEntity<Slice<PostDto.ResponseDto>> getPostsByLatest(
+            @PageableDefault(size = 10, sort = "createdAt",
+                    direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        // 서비스 레이어에서 최신 게시물 조회
+        Slice<PostDto.ResponseDto> postsSlice = postService.getPostsByLatest(pageable);
+        // 조회 결과 반환
+        return ResponseEntity.ok(postsSlice);
+    }
     @GetMapping("/{postId}")
     public ResponseEntity<PostDto.ResponseDto> getPost(@PathVariable Long postId) {
         PostDto.ResponseDto responseDto = postService.getPost(postId);

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -5,6 +5,7 @@ import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.security.UserDetailsImpl;
 import com.nawabali.nawabali.service.PostService;
 import jakarta.mail.Multipart;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -28,14 +29,14 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<PostDto.ResponseDto> createPost(
-            @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestPart("requestDto") PostDto.RequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestPart("requestDto") PostDto.RequestDto requestDto,
             @RequestParam("files") List<MultipartFile> files) {
         PostDto.ResponseDto responseDto = postService.createPost(userDetails.getUser(), requestDto, files);
         return ResponseEntity.ok(responseDto);
     }
 
 
-    @GetMapping("/latest")
+    @GetMapping
     public ResponseEntity<Slice<PostDto.ResponseDto>> getPostsByLatest(
             @PageableDefault(size = 10, sort = "createdAt",
                     direction = Sort.Direction.DESC) Pageable pageable
@@ -45,6 +46,7 @@ public class PostController {
         // 조회 결과 반환
         return ResponseEntity.ok(postsSlice);
     }
+    
     @GetMapping("/{postId}")
     public ResponseEntity<PostDto.ResponseDto> getPost(@PathVariable Long postId) {
         PostDto.ResponseDto responseDto = postService.getPost(postId);

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -3,9 +3,15 @@ package com.nawabali.nawabali.dto;
 import com.nawabali.nawabali.constant.Address;
 import com.nawabali.nawabali.constant.Category;
 import com.nawabali.nawabali.domain.Post;
+import com.nawabali.nawabali.domain.image.PostImage;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class PostDto {
 
@@ -16,14 +22,19 @@ public class PostDto {
     @Builder
     public static class RequestDto {
 
+        @NotBlank
         private String title;
 
+        @NotBlank
         private String contents;
 
+        @NotBlank
         private Category category;
 
+        @NotBlank
         private Double latitude;
 
+        @NotBlank
         private Double longitude;
 
     }
@@ -51,15 +62,21 @@ public class PostDto {
 
         private LocalDateTime modifiedAt;
 
+        private List<String> imageUrls;
+
         public ResponseDto(Post post) {
             this.userId = post.getUser().getId();
             this.postId = post.getId();
             this.nickname = post.getUser().getNickname();
             this.title = post.getTitle();
             this.contents = post.getContents();
-            this.category = post.getContents();
+            this.category = post.getCategory().name();
             this.createdAt = post.getCreatedAt();
             this.modifiedAt = post.getModifiedAt();
+            this.imageUrls = post.getImages().stream()
+                    .map(PostImage::getImgUrl)
+                    .collect(Collectors.toList());
+
         }
 
     }

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -61,6 +61,7 @@ public class PostDto {
             this.createdAt = post.getCreatedAt();
             this.modifiedAt = post.getModifiedAt();
         }
+
     }
 
     @Getter

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/SignupDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/SignupDto.java
@@ -1,6 +1,7 @@
 package com.nawabali.nawabali.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
@@ -14,19 +15,21 @@ public class SignupDto {
     public static class SignupRequestDto{
 
         @Email
+        @NotBlank
         private String email;
 
-//        @Schema(description = "이름", example = "steeve")
+        @NotBlank
         private String username;
 
+        @NotBlank
         private String nickname;
 
 //        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*\\W)[a-zA-Z0-9\\W]{8,15}$",
 //                message = "대문자, 소문자, 특수문자, 숫자 포함 8~15자리.")
-//        @Schema(description = "8자~15자 이내의 비밀번호", example = "StrongP@ss123")
         private String password;
+
         private String confirmPassword;
-//        @Schema(description = "사용자 역할", example = "ADMIN")
+
         private boolean admin;
 
         private boolean certificated;
@@ -36,9 +39,6 @@ public class SignupDto {
 
         private String district;
 
-        private String street;
-
-        private String zipcode;
     }
 
     @Getter

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/PostImageRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/PostImageRepository.java
@@ -1,0 +1,13 @@
+package com.nawabali.nawabali.repository;
+
+import com.nawabali.nawabali.domain.image.PostImage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+    List<PostImage> findAllByPostId(Long postId);
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/PostRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/PostRepository.java
@@ -1,9 +1,10 @@
 package com.nawabali.nawabali.repository;
 
 import com.nawabali.nawabali.domain.Post;
+import com.nawabali.nawabali.repository.dslrepository.PostDslRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long> , PostDslRepositoryCustom {
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustom.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.nawabali.nawabali.repository.dslrepository;
+
+import com.nawabali.nawabali.domain.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface PostDslRepositoryCustom {
+
+    Slice<Post> findPostsByLatest(Pageable pageable);
+
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustomImpl.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.nawabali.nawabali.repository.dslrepository;
+
+import com.nawabali.nawabali.domain.Post;
+import com.nawabali.nawabali.domain.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Autowired
+    public PostDslRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Slice<Post> findPostsByLatest(Pageable pageable) {
+        QPost post = QPost.post;
+        List<Post> posts = queryFactory
+                .selectFrom(post)
+                .orderBy(post.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+
+        if (posts.size() > pageable.getPageSize()) {
+            posts.remove(posts.size() - 1);
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(posts, pageable, hasNext);
+    }
+
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustomImpl.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustomImpl.java
@@ -27,16 +27,18 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         QPost post = QPost.post;
         List<Post> posts = queryFactory
                 .selectFrom(post)
-                .orderBy(post.createdAt.desc())
+                .orderBy(post.createdAt.desc())     // 최신순으로 정렬(맨위가 최신)
                 .offset(pageable.getOffset())
+                // Slice는 카운트 쿼리가 없는 대신에 게시물이 더 존재 하는지 알아야 함.
+                // 따라서 요청한 size 보다 1개 더 넣어줘서 반환된 개수를 통해 다음 페이지 여부를 판단
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
         boolean hasNext = false;
 
-        if (posts.size() > pageable.getPageSize()) {
+        if (posts.size() > pageable.getPageSize()) {    // 다음 페이지가 존재하는지 확인(다음 페이지의 존재 유무를 확인하기 위함)
             posts.remove(posts.size() - 1);
-            hasNext = true;
+            hasNext = true;     // 다음 페이지가 있음을 알려줌 false -> true
         }
 
         return new SliceImpl<>(posts, pageable, hasNext);

--- a/nawabali/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -8,16 +8,21 @@ import com.nawabali.nawabali.domain.image.PostImage;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.exception.CustomException;
 import com.nawabali.nawabali.exception.ErrorCode;
+import com.nawabali.nawabali.repository.PostImageRepository;
 import com.nawabali.nawabali.repository.PostRepository;
 import com.nawabali.nawabali.s3.AwsS3Service;
 import jakarta.mail.Multipart;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +30,7 @@ import java.util.List;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
     private final UserService userService;
     private final AwsS3Service awsS3Service;
 
@@ -63,6 +69,27 @@ public class PostService {
     }
 
     // 전체 게시물 조회 - 무한 스크롤
+    @Transactional(readOnly = true)
+    public Slice<PostDto.ResponseDto> getPostsByLatest(Pageable pageable) {
+        Slice<Post> postSlice = postRepository.findPostsByLatest(pageable);
+        List<PostDto.ResponseDto> content = postSlice.getContent().stream()
+                .map(post -> {
+                    return new PostDto.ResponseDto(
+                            post.getUser().getId(),
+                            post.getId(),
+                            post.getUser().getNickname(),
+                            post.getTitle(),
+                            post.getContents(),
+                            post.getCategory().name(),  // enum을 string으로 변환
+                            post.getCreatedAt(),
+                            post.getModifiedAt()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new SliceImpl<>(content, pageable, postSlice.hasNext());
+    }
+
 
 
     // 게시물 조회
@@ -93,9 +120,18 @@ public class PostService {
     // 게시물 삭제
     @Transactional
     public PostDto.DeleteDto deletePost(Long postId) {
+
+        List<PostImage> images = postImageRepository.findAllByPostId(postId);
+
+        // AWS S3에서 각 이미지 삭제
+        images.forEach(image -> {
+            awsS3Service.deleteFile(image.getFileName());
+        });
         postRepository.deleteById(postId);
+
         return new PostDto.DeleteDto("해당 게시물이 삭제되었습니다.");
     }
+
 
     public Post getPostId(Long postId) {
         return postRepository.findById(postId)


### PR DESCRIPTION
#20 게시물 무한 스크롤
- 게시물 조회 시 query dsl 사용하여 무한 스크롤 구현
- 게시물 상세 조회 시 사진 조회 추가 / 전체 조회 시 사진 조회 추가

+ merge 할 경우 Q파일 생성을 위해 querydsl 설정이 필요합니다.