### PR TITLE
프로필사진 생성, 수정, 삭제 구현

### DIFF
--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -44,16 +44,16 @@ public class UserController {
     @PostMapping("/{userId}/profileImage")
     public ResponseEntity<UserDto.ProfileImageDto> createProfileImage(@PathVariable Long userId,
                                                                       @AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                      MultipartFile multipartFile) {
-        UserDto.ProfileImageDto profileImageDto = userService.createProfileImage(userId, userDetails, multipartFile);
+                                                                      @RequestParam("file") MultipartFile file) {
+        UserDto.ProfileImageDto profileImageDto = userService.createProfileImage(userId, userDetails, file);
         return ResponseEntity.ok(profileImageDto);
     }
 
     @PatchMapping("/{userId}/profileImage")
     public ResponseEntity<UserDto.ProfileImageDto> updateProfileImage(@PathVariable Long userId,
                                                                       @AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                      MultipartFile multipartFile) {
-        UserDto.ProfileImageDto profileImageDto = userService.updateProfileImage(userId, userDetails, multipartFile);
+                                                                      @RequestParam("file") MultipartFile file) {
+        UserDto.ProfileImageDto profileImageDto = userService.updateProfileImage(userId, userDetails, file);
         return ResponseEntity.ok(profileImageDto);
     }
 

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -2,17 +2,16 @@ package com.nawabali.nawabali.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nawabali.nawabali.dto.SignupDto;
+import com.nawabali.nawabali.dto.UserDto;
 import com.nawabali.nawabali.security.UserDetailsImpl;
-import com.nawabali.nawabali.security.UserDetailsServiceImpl;
 import com.nawabali.nawabali.service.KakaoService;
 import com.nawabali.nawabali.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/users")
@@ -40,5 +39,28 @@ public class UserController {
     @GetMapping("test1")
     public void test1(@AuthenticationPrincipal UserDetailsImpl userDetails){
         System.out.println("userDetails.getUser() = " + userDetails.getUser().getEmail());
+    }
+
+    @PostMapping("/{userId}/profileImage")
+    public ResponseEntity<UserDto.ProfileImageDto> createProfileImage(@PathVariable Long userId,
+                                                                      @AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                      MultipartFile multipartFile) {
+        UserDto.ProfileImageDto profileImageDto = userService.createProfileImage(userId, userDetails, multipartFile);
+        return ResponseEntity.ok(profileImageDto);
+    }
+
+    @PatchMapping("/{userId}/profileImage")
+    public ResponseEntity<UserDto.ProfileImageDto> updateProfileImage(@PathVariable Long userId,
+                                                                      @AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                      MultipartFile multipartFile) {
+        UserDto.ProfileImageDto profileImageDto = userService.updateProfileImage(userId, userDetails, multipartFile);
+        return ResponseEntity.ok(profileImageDto);
+    }
+
+    @DeleteMapping("/{userId}/profileImage")
+    public ResponseEntity<UserDto.DeleteDto> deleteProfileImage(@PathVariable Long userId,
+                                     @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserDto.DeleteDto deleteDto = userService.deleteProfileImage(userId, userDetails);
+        return ResponseEntity.ok(deleteDto);
     }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
@@ -2,8 +2,11 @@ package com.nawabali.nawabali.domain;
 
 import com.nawabali.nawabali.constant.Address;
 import com.nawabali.nawabali.constant.UserRoleEnum;
+import com.nawabali.nawabali.domain.image.ProfileImage;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -34,6 +37,9 @@ public class User {
     private Address address;
 
     private Long kakaoId;
+
+    @OneToOne(mappedBy = "user")
+    private ProfileImage profileImage;
 
     @Builder
     public User(String username, String nickname, String email, String password, UserRoleEnum role, Address address) {

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
@@ -38,17 +38,22 @@ public class User {
 
     private Long kakaoId;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private ProfileImage profileImage;
 
     @Builder
-    public User(String username, String nickname, String email, String password, UserRoleEnum role, Address address) {
+    public User(String username, String nickname, String email, String password, UserRoleEnum role, Address address, ProfileImage profileImage) {
         this.username = username;
         this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.role = role;
         this.address = address;
+        this.profileImage = profileImage;
+
+        if (profileImage != null) {
+            profileImage.setUser(this);
+        }
     }
 
     @Builder

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/image/ProfileImage.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/image/ProfileImage.java
@@ -37,4 +37,8 @@ public class ProfileImage {
     public void updateImgUrl(String imgUrl) {
         this.imgUrl = imgUrl;
     }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/image/ProfileImage.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/image/ProfileImage.java
@@ -1,0 +1,40 @@
+package com.nawabali.nawabali.domain.image;
+
+import com.nawabali.nawabali.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class ProfileImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fileName;
+
+    private String imgUrl;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public ProfileImage(Long id, String fileName, String imgUrl, User user) {
+        this.id = id;
+        this.fileName = fileName;
+        this.imgUrl = imgUrl;
+        this.user = user;
+    }
+
+    public void updateFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public void updateImgUrl(String imgUrl) {
+        this.imgUrl = imgUrl;
+    }
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/UserDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/UserDto.java
@@ -1,5 +1,7 @@
 package com.nawabali.nawabali.dto;
 
+import com.nawabali.nawabali.domain.User;
+import com.nawabali.nawabali.domain.image.ProfileImage;
 import lombok.*;
 
 public class UserDto {
@@ -22,5 +24,31 @@ public class UserDto {
             this.nickname = nickname;
             this.email = email;
         }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ProfileImageDto {
+        Long id;
+        String fileName;
+        String imgUrl;
+        User user;
+
+        public ProfileImageDto(ProfileImage profileImage) {
+            this.id = profileImage.getId();
+            this.fileName = profileImage.getFileName();
+            this.imgUrl = profileImage.getImgUrl();
+            this.user = profileImage.getUser();
+        }
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class DeleteDto {
+        private String message;
     }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/UserDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/UserDto.java
@@ -33,13 +33,13 @@ public class UserDto {
         Long id;
         String fileName;
         String imgUrl;
-        User user;
+        Long userId;
 
         public ProfileImageDto(ProfileImage profileImage) {
             this.id = profileImage.getId();
             this.fileName = profileImage.getFileName();
             this.imgUrl = profileImage.getImgUrl();
-            this.user = profileImage.getUser();
+            this.userId = profileImage.getUser().getId();
         }
     }
 

--- a/nawabali/src/main/java/com/nawabali/nawabali/exception/ErrorCode.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     POST_NOT_FOUND(NOT_FOUND, "해당 게시물 정보를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글 정보를 찾을 수 없습니다."),
     USER_NOT_FOUND(NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    PROFILEIMAGE_NOT_FOUND(NOT_FOUND, "해당 프로필이미지를 찾을 수 없습니다."),
 
 
     // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/ProfileImageRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/ProfileImageRepository.java
@@ -1,0 +1,7 @@
+package com.nawabali.nawabali.repository;
+
+import com.nawabali.nawabali.domain.image.ProfileImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/s3/AwsS3Service.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/s3/AwsS3Service.java
@@ -69,4 +69,21 @@ public class AwsS3Service {
         amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
         System.out.println(bucket);
     }
+
+    public String uploadSingleFile(MultipartFile multipartFile, String dirName){
+        String fileName = createFileName(multipartFile.getOriginalFilename());
+        String filePath = dirName + "/" + fileName; // 폴더 경로 추가
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, filePath, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+            // S3 URL 생성 및 리스트에 추가
+            return amazonS3.getUrl(bucket, filePath).toString();
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+        }
+    }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/service/UserService.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/service/UserService.java
@@ -3,21 +3,28 @@ package com.nawabali.nawabali.service;
 import com.nawabali.nawabali.constant.Address;
 import com.nawabali.nawabali.constant.UserRoleEnum;
 import com.nawabali.nawabali.domain.User;
+import com.nawabali.nawabali.domain.image.ProfileImage;
 import com.nawabali.nawabali.dto.SignupDto;
+import com.nawabali.nawabali.dto.UserDto;
 import com.nawabali.nawabali.exception.CustomException;
 import com.nawabali.nawabali.exception.ErrorCode;
+import com.nawabali.nawabali.repository.ProfileImageRepository;
 import com.nawabali.nawabali.repository.UserRepository;
+import com.nawabali.nawabali.s3.AwsS3Service;
+import com.nawabali.nawabali.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-
+    private final AwsS3Service awsS3Service;
+    private final ProfileImageRepository profileImageRepository;
 
     @Transactional
     public SignupDto.SignupResponseDto signup(SignupDto.SignupRequestDto requestDto) {
@@ -66,6 +73,49 @@ public class UserService {
     public User getUserId(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
 
+    @Transactional
+    public UserDto.ProfileImageDto createProfileImage(Long userId, UserDetailsImpl userDetails, MultipartFile multipartFile) {
+        if(!userId.equals(userDetails.getUser().getId())){
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        String url = awsS3Service.uploadSingleFile(multipartFile, "profileImage");
+        ProfileImage profileImage = ProfileImage.builder()
+                .fileName(url)
+                .imgUrl(url)
+                .build();
+        profileImageRepository.save(profileImage);
+        return new UserDto.ProfileImageDto(profileImage);
+    }
+
+    @Transactional
+    public UserDto.ProfileImageDto updateProfileImage(Long userId, UserDetailsImpl userDetails, MultipartFile multipartFile) {
+        User user = userDetails.getUser();
+        if(!userId.equals(user.getId())){
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        String url = awsS3Service.uploadSingleFile(multipartFile, "profileImage");
+
+        ProfileImage profileImage = profileImageRepository.findById(user.getProfileImage().getId()).orElseThrow(()->
+                new CustomException(ErrorCode.PROFILEIMAGE_NOT_FOUND));
+        profileImage.updateFileName(url);
+        profileImage.updateImgUrl(url);
+        profileImageRepository.save(profileImage);
+
+        return new UserDto.ProfileImageDto(profileImage);
+    }
+
+    @Transactional
+    public UserDto.DeleteDto deleteProfileImage(Long userId, UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        if(!userId.equals(user.getId())){
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        ProfileImage profileImage = profileImageRepository.findById(user.getProfileImage().getId()).orElseThrow(()->
+                new CustomException(ErrorCode.PROFILEIMAGE_NOT_FOUND));
+        awsS3Service.deleteFile(profileImage.getFileName());
+        profileImageRepository.delete(profileImage);
+        return new UserDto.DeleteDto("프로필사진이 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
### 관련 이슈
* close #21 

### 변경사항
* ProfileImage 관련 entity, repository 생성
* UserController, UserService에 프로필 관련 API 추가
* ProfileImage와 User 간 일대일 양방향 연관관계 설정 위해  User entity 수정됨

### 확인 요청사항
* deleteProfileImage : S3 서버 내 저장된 URL 삭제 권한 부재로 인해 deleteFile 메서드 실행 불가
-> S3 서버 삭제 권한 부여 및 AWS 계정 팀내 공유 관련 검토 필요
* 프로필 기본사진 지정 방식 논의 필요
&nbsp; 1. S3 서버 내 미리 저장해둔 특정 이미지로 ProfileImage에 초기값 설정 
&nbsp; 2. 프론트엔드단에서 별도 처리

### 포스트맨 확인
* createProfileImage 결과
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/ee191edf-9df4-4bc3-9c0c-21608b2cff2f)

* updateProfileImage 결과
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/3462463e-b8be-474c-bfcf-6797d074eb4e)

* deleteProfileImage 결과
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/584045bb-c0c3-49f5-867f-2b805638ee66)


