### PR TITLE
Feat : 댓글 조회 무한 스크롤 & 게시물 조회 부분 수정

### DIFF
--- a/nawabali/src/main/generated/com/nawabali/nawabali/domain/QPost.java
+++ b/nawabali/src/main/generated/com/nawabali/nawabali/domain/QPost.java
@@ -34,6 +34,8 @@ public class QPost extends EntityPathBase<Post> {
 
     public final ListPath<com.nawabali.nawabali.domain.image.PostImage, com.nawabali.nawabali.domain.image.QPostImage> images = this.<com.nawabali.nawabali.domain.image.PostImage, com.nawabali.nawabali.domain.image.QPostImage>createList("images", com.nawabali.nawabali.domain.image.PostImage.class, com.nawabali.nawabali.domain.image.QPostImage.class, PathInits.DIRECT2);
 
+    public final ListPath<Like, QLike> likes = this.<Like, QLike>createList("likes", Like.class, QLike.class, PathInits.DIRECT2);
+
     public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
 
     public final StringPath title = createString("title");

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/CommentController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/CommentController.java
@@ -1,9 +1,14 @@
 package com.nawabali.nawabali.controller;
 
 import com.nawabali.nawabali.dto.CommentDto;
+import com.nawabali.nawabali.dto.dslDto.CommentDslDto;
 import com.nawabali.nawabali.service.CommentService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -37,5 +42,12 @@ public class CommentController {
     public CommentDto.DeleteResponseDto deleteComment (@PathVariable("commentId") Long commentId,
                                                  @AuthenticationPrincipal UserDetails userDetails) {
         return commentService.deleteComment (commentId, userDetails.getUsername());
+    }
+
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<Slice<CommentDslDto.ResponseDto>> getComments(@PathVariable Long postId,
+                                                                        @PageableDefault(size = 10)Pageable pageable) {
+        Slice<CommentDslDto.ResponseDto> comments = commentService.getComments(postId,pageable);
+        return ResponseEntity.ok(comments);
     }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -38,9 +38,9 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<Slice<PostDto.ResponseDto>> getPostsByLatest(
-            @PageableDefault(size = 10, sort = "createdAt",
-                    direction = Sort.Direction.DESC) Pageable pageable
-    ) {
+            @PageableDefault(size = 10,
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC) Pageable pageable) {
         Slice<PostDto.ResponseDto> postsSlice = postService.getPostsByLatest(pageable);
         // 조회 결과 반환
         return ResponseEntity.ok(postsSlice);
@@ -53,7 +53,8 @@ public class PostController {
     }
 
     @PatchMapping("/{postId}")
-    public ResponseEntity<PostDto.ResponseDto> updatePost(@PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails,
+    public ResponseEntity<PostDto.ResponseDto> updatePost(@PathVariable Long postId,
+                                                          @AuthenticationPrincipal UserDetailsImpl userDetails,
                                                           @RequestBody PostDto.PatchDto patchDto) {
         PostDto.ResponseDto responseDto = postService.updatePost(postId,userDetails.getUser(),patchDto);
         return ResponseEntity.ok(responseDto);

--- a/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -53,10 +53,10 @@ public class PostController {
     }
 
     @PatchMapping("/{postId}")
-    public ResponseEntity<PostDto.ResponseDto> updatePost(@PathVariable Long postId,
+    public ResponseEntity<PostDto.PatchDto> updatePost(@PathVariable Long postId,
                                                           @AuthenticationPrincipal UserDetailsImpl userDetails,
                                                           @RequestBody PostDto.PatchDto patchDto) {
-        PostDto.ResponseDto responseDto = postService.updatePost(postId,userDetails.getUser(),patchDto);
+        PostDto.PatchDto responseDto = postService.updatePost(postId,userDetails.getUser(),patchDto);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/Like.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/Like.java
@@ -25,9 +25,6 @@ public class Like {
     @Column (nullable = false)
     private boolean status;
 
-//    @Column (nullable = false)
-//    private Long likesCount;
-
     @ManyToOne (fetch = FetchType.LAZY) // 성능향상에 좋다.
     @JoinColumn (name = "user_id")
     private User user;

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/Post.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/Post.java
@@ -67,11 +67,9 @@ public class Post {
         this.user = user;
     }
 
-    public void update(String title, String contents, Category category, Town town) {
+    public void update(String title, String contents) {
         this.title = title;
         this.contents = contents;
-        this.category = category;
-        this.town = town;
     }
 
     // 이미지 생성

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/Post.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/Post.java
@@ -50,6 +50,9 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Like> likes = new ArrayList<>();
+
 
     @Builder
     public Post(String title, String contents, LocalDateTime createdAt, LocalDateTime modifiedAt,

--- a/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/domain/User.java
@@ -16,6 +16,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor
+@Table(name = "users")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -44,7 +44,7 @@ public class PostDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class ResponseDto {
+    public static class ResponseDto {       // 게시물 전체 조회 시
 
         private Long userId;
 
@@ -94,7 +94,7 @@ public class PostDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class ResponseDetailDto {
+    public static class ResponseDetailDto {     // 게시물 상세 조회 시
 
         private Long userId;
 
@@ -116,8 +116,6 @@ public class PostDto {
 
         private int commentCount;
 
-        private List<CommentDto.DetailResponseDto> comments;
-
         private Long likesCount;
 
         private Long localLikesCount;
@@ -136,15 +134,6 @@ public class PostDto {
                     .map(PostImage::getImgUrl)
                     .collect(Collectors.toList());
             this.commentCount = post.getComments().size();
-            this.comments = post.getComments().stream().map(comment -> CommentDto.DetailResponseDto.builder()
-                    .postId(comment.getPost().getId())
-                    .userId(comment.getUser().getId())
-                    .commentId(comment.getId())
-                    .nickname(comment.getUser().getNickname())
-                    .contents(comment.getContents())
-                    .createdAt(comment.getCreatedAt())
-                    .modifiedAt(comment.getModifiedAt())
-                    .build()).collect(Collectors.toList());
             this.likesCount = likesCount;
             this.localLikesCount = localLikesCount;
         }

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -151,12 +151,10 @@ public class PostDto {
 
         private String contents;
 
-        private Category category;
-
-        private Double latitude;
-
-        private Double longitude;
-
+        public PatchDto(Post post) {
+            this.title = post.getTitle();
+            this.contents = post.getContents();
+        }
     }
 
     @Getter

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/dslDto/CommentDslDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/dslDto/CommentDslDto.java
@@ -1,0 +1,17 @@
+package com.nawabali.nawabali.dto.dslDto;
+
+import lombok.*;
+
+public class CommentDslDto {
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ResponseDto {
+
+        private String contents;
+
+        private String username;
+    }
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/dto/dslDto/PostDslDto.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/dto/dslDto/PostDslDto.java
@@ -1,0 +1,62 @@
+package com.nawabali.nawabali.dto.dslDto;
+
+import com.nawabali.nawabali.domain.Post;
+import com.nawabali.nawabali.domain.image.PostImage;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PostDslDto {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ResponseDto {
+
+        private Long userId;
+
+        private Long postId;
+
+        private String nickname;
+
+        private String title;
+
+        private String contents;
+
+        private String category;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime modifiedAt;
+
+        private List<String> imageUrls;
+
+        private Long likesCount;
+
+        private Long localLikesCount;
+
+        private int commentCount;
+
+        public ResponseDto(Post post, Long likesCount, Long localLikesCount) {
+            this.userId = post.getUser().getId();
+            this.postId = post.getId();
+            this.nickname = post.getUser().getNickname();
+            this.title = post.getTitle();
+            this.contents = post.getContents();
+            this.category = post.getCategory().name();
+            this.createdAt = post.getCreatedAt();
+            this.modifiedAt = post.getModifiedAt();
+            this.imageUrls = post.getImages().stream()
+                    .map(PostImage::getImgUrl)
+                    .collect(Collectors.toList());
+            this.commentCount = post.getComments().size();
+            this.likesCount = likesCount;
+            this.localLikesCount = localLikesCount;
+        }
+
+    }
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/CommentRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/CommentRepository.java
@@ -2,13 +2,15 @@ package com.nawabali.nawabali.repository;
 
 import com.nawabali.nawabali.domain.Comment;
 import com.nawabali.nawabali.dto.CommentDto;
+import com.nawabali.nawabali.repository.dslrepository.CommentDslRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-
-public interface CommentRepository extends JpaRepository <Comment, Long> {
+@Repository
+public interface CommentRepository extends JpaRepository <Comment, Long> , CommentDslRepositoryCustom {
     Optional<Comment> findByPostIdAndId(Long postId, Long commentId);
 
     List<CommentDto.ResponseDto> findByPostId(Long postId);

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/LikeRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/LikeRepository.java
@@ -5,9 +5,11 @@ import com.nawabali.nawabali.domain.Like;
 import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface LikeRepository extends JpaRepository <Like, Long> {
 
     Optional<Like> findByUserAndPost (User user, Post post);

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/ProfileImageRepository.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/ProfileImageRepository.java
@@ -2,6 +2,8 @@ package com.nawabali.nawabali.repository;
 
 import com.nawabali.nawabali.domain.image.ProfileImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/CommentDslRepositoryCustom.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/CommentDslRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.nawabali.nawabali.repository.dslrepository;
+
+import com.nawabali.nawabali.dto.dslDto.CommentDslDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CommentDslRepositoryCustom {
+    Slice<CommentDslDto.ResponseDto> findCommentsByPostId(Long postId, Pageable pageable);
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/CommentDslRepositoryCustomImpl.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/CommentDslRepositoryCustomImpl.java
@@ -1,0 +1,50 @@
+package com.nawabali.nawabali.repository.dslrepository;
+
+import com.nawabali.nawabali.domain.QComment;
+import com.nawabali.nawabali.domain.QUser;
+import com.nawabali.nawabali.dto.dslDto.CommentDslDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class CommentDslRepositoryCustomImpl implements CommentDslRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Autowired
+    public CommentDslRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Slice<CommentDslDto.ResponseDto> findCommentsByPostId(Long postId, Pageable pageable) {
+        QComment comment = QComment.comment;
+
+        List<CommentDslDto.ResponseDto> comments = queryFactory
+                .select(Projections.bean(CommentDslDto.ResponseDto.class,
+                        comment.contents,
+                        comment.user.username))
+                .from(comment)
+                .where(comment.post.id.eq(postId))
+                .orderBy(comment.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize()+1)
+                .fetch();
+
+        boolean hasNext = comments.size() > pageable.getPageSize();
+        if(hasNext) {
+            comments.remove(comments.size() - 1);
+        }
+
+        return new SliceImpl<>(comments, pageable, hasNext);
+
+    }
+}

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustom.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustom.java
@@ -1,11 +1,12 @@
 package com.nawabali.nawabali.repository.dslrepository;
 
 import com.nawabali.nawabali.domain.Post;
+import com.nawabali.nawabali.dto.dslDto.PostDslDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface PostDslRepositoryCustom {
 
-    Slice<Post> findPostsByLatest(Pageable pageable);
+    Slice<PostDslDto.ResponseDto> findPostsByLatest(Pageable pageable);
 
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustomImpl.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/repository/dslrepository/PostDslRepositoryCustomImpl.java
@@ -2,8 +2,15 @@ package com.nawabali.nawabali.repository.dslrepository;
 
 import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.domain.QPost;
+import com.nawabali.nawabali.domain.QUser;
+import com.nawabali.nawabali.domain.image.PostImage;
+import com.nawabali.nawabali.dto.PostDto;
+import com.nawabali.nawabali.dto.dslDto.PostDslDto;
+import com.nawabali.nawabali.repository.LikeRepository;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,6 +18,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
@@ -22,26 +30,40 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         this.queryFactory = new JPAQueryFactory(em);
     }
 
+
     @Override
-    public Slice<Post> findPostsByLatest(Pageable pageable) {
+    public Slice<PostDslDto.ResponseDto> findPostsByLatest(Pageable pageable) {
         QPost post = QPost.post;
+        QUser user = QUser.user;
+
         List<Post> posts = queryFactory
                 .selectFrom(post)
-                .orderBy(post.createdAt.desc())     // 최신순으로 정렬(맨위가 최신)
+                .leftJoin(post.user, user).fetchJoin()
+                .orderBy(post.createdAt.desc())
                 .offset(pageable.getOffset())
-                // Slice는 카운트 쿼리가 없는 대신에 게시물이 더 존재 하는지 알아야 함.
-                // 따라서 요청한 size 보다 1개 더 넣어줘서 반환된 개수를 통해 다음 페이지 여부를 판단
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        boolean hasNext = false;
-
-        if (posts.size() > pageable.getPageSize()) {    // 다음 페이지가 존재하는지 확인(다음 페이지의 존재 유무를 확인하기 위함)
+        boolean hasNext = posts.size() > pageable.getPageSize();
+        if(hasNext) {
             posts.remove(posts.size() - 1);
-            hasNext = true;     // 다음 페이지가 있음을 알려줌 false -> true
         }
 
-        return new SliceImpl<>(posts, pageable, hasNext);
-    }
+        List<PostDslDto.ResponseDto> responseDtos = posts.stream()
+                .map(newPost -> PostDslDto.ResponseDto.builder()
+                        .userId(newPost.getUser().getId())
+                        .postId(newPost.getId())
+                        .nickname(newPost.getUser().getNickname())
+                        .title(newPost.getTitle())
+                        .contents(newPost.getContents())
+                        .category(newPost.getCategory().name())
+                        .createdAt(newPost.getCreatedAt())
+                        .modifiedAt(newPost.getModifiedAt())
+                        .imageUrls(newPost.getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
+                        .commentCount(newPost.getComments().size())
+                        .build())
+                .collect(Collectors.toList());
 
+        return new SliceImpl<>(responseDtos, pageable, hasNext);
+    }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/service/CommentService.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/service/CommentService.java
@@ -4,6 +4,7 @@ import com.nawabali.nawabali.domain.Comment;
 import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.domain.User;
 import com.nawabali.nawabali.dto.CommentDto;
+import com.nawabali.nawabali.dto.dslDto.CommentDslDto;
 import com.nawabali.nawabali.exception.CustomException;
 import com.nawabali.nawabali.exception.ErrorCode;
 import com.nawabali.nawabali.repository.CommentRepository;
@@ -11,6 +12,8 @@ import com.nawabali.nawabali.repository.PostRepository;
 import com.nawabali.nawabali.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -126,5 +129,10 @@ public class CommentService {
                 .commentId(commentId)
                 .message("댓글이 삭제되었습니다.")
                 .build();
+    }
+
+    // 댓글 조회(무한 스크롤)
+    public Slice<CommentDslDto.ResponseDto> getComments(Long postId, Pageable pageable) {
+        return commentRepository.findCommentsByPostId(postId , pageable);
     }
 }

--- a/nawabali/src/main/java/com/nawabali/nawabali/service/KakaoService.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/service/KakaoService.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,8 @@ public class KakaoService {
     private final RedisTool redisTool;
     private final RestTemplate restTemplate;
 
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
 
     @Transactional
     public void kakaoLogin(String code , HttpServletResponse response) throws JsonProcessingException {
@@ -65,7 +68,7 @@ public class KakaoService {
         // HTTP Body 생성
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
-        body.add("client_id", "52329a0a112266267bafd3864529e810");
+        body.add("client_id", clientId);
         body.add("redirect_uri", redirect_uri);
         body.add("code", code);
 

--- a/nawabali/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/nawabali/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -115,20 +115,16 @@ public class PostService {
 
     // 게시물 수정 - 사용자 신원 확인
     @Transactional
-    public PostDto.ResponseDto updatePost(Long postId, User user, PostDto.PatchDto patchDto) {
+    public PostDto.PatchDto updatePost(Long postId, User user, PostDto.PatchDto patchDto) {
         Post post = getPostId(postId);
         if(!post.getUser().getId().equals(user.getId())){
             throw new CustomException(ErrorCode.FORBIDDEN_MEMBER);
         }
 
-        Town town = new Town(patchDto.getLatitude(), patchDto.getLongitude());
+        post.update(patchDto.getTitle(), patchDto.getContents());
+        postRepository.save(post);
 
-        post.update(patchDto.getTitle(),
-                patchDto.getContents(),
-                patchDto.getCategory(),
-                town);
-
-        return new PostDto.ResponseDto(post);
+        return new PostDto.PatchDto(post);
     }
 
 


### PR DESCRIPTION
- close #39 댓글 조회 무한 스크롤 & 게시물 조회 부분 수정

## <구현내용>

1. 댓글 조회 시 무한 스크롤
<img width="813" alt="스크린샷 2024-04-03 오후 6 06 00" src="https://github.com/Nawabali-project/Nawabali-BE/assets/105621255/8a11ba6a-bdd4-43de-8203-0a4d2b089e84">

2.  게시물 상세 조회 시 댓글 조회를 하지 않고 댓글 조회 api를 분리(서버 부담 최소화)
3. 게시물 전체 조회 시 패치조인을 사용하여 post 엔티티를 가져올 때 user 엔티티도 한번에 쿼리로 가져오도록 변경( 추가적인 쿼리를 발생시키지 않기 위해 , N+1문제 해결 )
