### PR TITLE
게시물 내용 검색 기능

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,5 +13,12 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="nawabali@localhost" uuid="a3736315-5c2d-4acc-bbb7-08cc52c29a52">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/nawabali</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+	// elastic search
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	// Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/generated/com/nawabali/nawabali/constant/QAddress.java
+++ b/src/main/generated/com/nawabali/nawabali/constant/QAddress.java
@@ -1,0 +1,39 @@
+package com.nawabali.nawabali.constant;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAddress is a Querydsl query type for Address
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAddress extends BeanPath<Address> {
+
+    private static final long serialVersionUID = 458720951L;
+
+    public static final QAddress address = new QAddress("address");
+
+    public final StringPath city = createString("city");
+
+    public final StringPath district = createString("district");
+
+    public QAddress(String variable) {
+        super(Address.class, forVariable(variable));
+    }
+
+    public QAddress(Path<? extends Address> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAddress(PathMetadata metadata) {
+        super(Address.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/constant/QTown.java
+++ b/src/main/generated/com/nawabali/nawabali/constant/QTown.java
@@ -1,0 +1,39 @@
+package com.nawabali.nawabali.constant;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTown is a Querydsl query type for Town
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QTown extends BeanPath<Town> {
+
+    private static final long serialVersionUID = 266153647L;
+
+    public static final QTown town = new QTown("town");
+
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
+    public QTown(String variable) {
+        super(Town.class, forVariable(variable));
+    }
+
+    public QTown(Path<? extends Town> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTown(PathMetadata metadata) {
+        super(Town.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/QBookMark.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/QBookMark.java
@@ -1,0 +1,56 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBookMark is a Querydsl query type for BookMark
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBookMark extends EntityPathBase<BookMark> {
+
+    private static final long serialVersionUID = -1322001773L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBookMark bookMark = new QBookMark("bookMark");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QPost post;
+
+    public final BooleanPath status = createBoolean("status");
+
+    public final QUser user;
+
+    public QBookMark(String variable) {
+        this(BookMark.class, forVariable(variable), INITS);
+    }
+
+    public QBookMark(Path<? extends BookMark> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBookMark(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBookMark(PathMetadata metadata, PathInits inits) {
+        this(BookMark.class, metadata, inits);
+    }
+
+    public QBookMark(Class<? extends BookMark> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/QComment.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/QComment.java
@@ -1,0 +1,60 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = -1373662846L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final StringPath contents = createString("contents");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> Id = createNumber("Id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public final QPost post;
+
+    public final QUser user;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/QLike.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/QLike.java
@@ -1,0 +1,58 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLike is a Querydsl query type for Like
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLike extends EntityPathBase<Like> {
+
+    private static final long serialVersionUID = 928094036L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLike like = new QLike("like1");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<com.nawabali.nawabali.constant.LikeCategoryEnum> likeCategoryEnum = createEnum("likeCategoryEnum", com.nawabali.nawabali.constant.LikeCategoryEnum.class);
+
+    public final QPost post;
+
+    public final BooleanPath status = createBoolean("status");
+
+    public final QUser user;
+
+    public QLike(String variable) {
+        this(Like.class, forVariable(variable), INITS);
+    }
+
+    public QLike(Path<? extends Like> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLike(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLike(PathMetadata metadata, PathInits inits) {
+        this(Like.class, metadata, inits);
+    }
+
+    public QLike(Class<? extends Like> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/QPost.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/QPost.java
@@ -1,0 +1,70 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPost is a Querydsl query type for Post
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPost extends EntityPathBase<Post> {
+
+    private static final long serialVersionUID = 928219229L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPost post = new QPost("post");
+
+    public final EnumPath<com.nawabali.nawabali.constant.Category> category = createEnum("category", com.nawabali.nawabali.constant.Category.class);
+
+    public final ListPath<Comment, QComment> comments = this.<Comment, QComment>createList("comments", Comment.class, QComment.class, PathInits.DIRECT2);
+
+    public final StringPath contents = createString("contents");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<com.nawabali.nawabali.domain.image.PostImage, com.nawabali.nawabali.domain.image.QPostImage> images = this.<com.nawabali.nawabali.domain.image.PostImage, com.nawabali.nawabali.domain.image.QPostImage>createList("images", com.nawabali.nawabali.domain.image.PostImage.class, com.nawabali.nawabali.domain.image.QPostImage.class, PathInits.DIRECT2);
+
+    public final ListPath<Like, QLike> likes = this.<Like, QLike>createList("likes", Like.class, QLike.class, PathInits.DIRECT2);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public final StringPath title = createString("title");
+
+    public final com.nawabali.nawabali.constant.QTown town;
+
+    public final QUser user;
+
+    public QPost(String variable) {
+        this(Post.class, forVariable(variable), INITS);
+    }
+
+    public QPost(Path<? extends Post> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPost(PathMetadata metadata, PathInits inits) {
+        this(Post.class, metadata, inits);
+    }
+
+    public QPost(Class<? extends Post> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.town = inits.isInitialized("town") ? new com.nawabali.nawabali.constant.QTown(forProperty("town")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/QTimeStamp.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/QTimeStamp.java
@@ -1,0 +1,39 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTimeStamp is a Querydsl query type for TimeStamp
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QTimeStamp extends EntityPathBase<TimeStamp> {
+
+    private static final long serialVersionUID = -14442663L;
+
+    public static final QTimeStamp timeStamp = new QTimeStamp("timeStamp");
+
+    public final DateTimePath<java.time.LocalDateTime> createAt = createDateTime("createAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public QTimeStamp(String variable) {
+        super(TimeStamp.class, forVariable(variable));
+    }
+
+    public QTimeStamp(Path<? extends TimeStamp> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTimeStamp(PathMetadata metadata) {
+        super(TimeStamp.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/QUser.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/QUser.java
@@ -1,0 +1,70 @@
+package com.nawabali.nawabali.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 928371592L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUser user = new QUser("user");
+
+    public final com.nawabali.nawabali.constant.QAddress address;
+
+    public final ListPath<BookMark, QBookMark> bookMarks = this.<BookMark, QBookMark>createList("bookMarks", BookMark.class, QBookMark.class, PathInits.DIRECT2);
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath kakaoId = createString("kakaoId");
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final com.nawabali.nawabali.domain.image.QProfileImage profileImage;
+
+    public final EnumPath<com.nawabali.nawabali.constant.UserRankEnum> rank = createEnum("rank", com.nawabali.nawabali.constant.UserRankEnum.class);
+
+    public final EnumPath<com.nawabali.nawabali.constant.UserRoleEnum> role = createEnum("role", com.nawabali.nawabali.constant.UserRoleEnum.class);
+
+    public final StringPath username = createString("username");
+
+    public QUser(String variable) {
+        this(User.class, forVariable(variable), INITS);
+    }
+
+    public QUser(Path<? extends User> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUser(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new com.nawabali.nawabali.constant.QAddress(forProperty("address")) : null;
+        this.profileImage = inits.isInitialized("profileImage") ? new com.nawabali.nawabali.domain.image.QProfileImage(forProperty("profileImage"), inits.get("profileImage")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/image/QPostImage.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/image/QPostImage.java
@@ -1,0 +1,55 @@
+package com.nawabali.nawabali.domain.image;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPostImage is a Querydsl query type for PostImage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPostImage extends EntityPathBase<PostImage> {
+
+    private static final long serialVersionUID = 260309995L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPostImage postImage = new QPostImage("postImage");
+
+    public final StringPath fileName = createString("fileName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imgUrl = createString("imgUrl");
+
+    public final com.nawabali.nawabali.domain.QPost post;
+
+    public QPostImage(String variable) {
+        this(PostImage.class, forVariable(variable), INITS);
+    }
+
+    public QPostImage(Path<? extends PostImage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPostImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPostImage(PathMetadata metadata, PathInits inits) {
+        this(PostImage.class, metadata, inits);
+    }
+
+    public QPostImage(Class<? extends PostImage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new com.nawabali.nawabali.domain.QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/nawabali/nawabali/domain/image/QProfileImage.java
+++ b/src/main/generated/com/nawabali/nawabali/domain/image/QProfileImage.java
@@ -1,0 +1,55 @@
+package com.nawabali.nawabali.domain.image;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProfileImage is a Querydsl query type for ProfileImage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProfileImage extends EntityPathBase<ProfileImage> {
+
+    private static final long serialVersionUID = 838815714L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProfileImage profileImage = new QProfileImage("profileImage");
+
+    public final StringPath fileName = createString("fileName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imgUrl = createString("imgUrl");
+
+    public final com.nawabali.nawabali.domain.QUser user;
+
+    public QProfileImage(String variable) {
+        this(ProfileImage.class, forVariable(variable), INITS);
+    }
+
+    public QProfileImage(Path<? extends ProfileImage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProfileImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProfileImage(PathMetadata metadata, PathInits inits) {
+        this(ProfileImage.class, metadata, inits);
+    }
+
+    public QProfileImage(Class<? extends ProfileImage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.nawabali.nawabali.domain.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/java/com/nawabali/nawabali/controller/PostSearchController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/PostSearchController.java
@@ -1,0 +1,26 @@
+package com.nawabali.nawabali.controller;
+
+import com.nawabali.nawabali.domain.elastic.PostSearch;
+import com.nawabali.nawabali.service.PostSearchService;
+import com.nawabali.nawabali.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class PostSearchController {
+
+    private final PostSearchService postSearchService;
+
+    @GetMapping("/posts")
+    public List<PostSearch> searchPostsByContents(@RequestParam("query") String query) {
+        return postSearchService.searchByContents(query);
+    }
+}

--- a/src/main/java/com/nawabali/nawabali/domain/Post.java
+++ b/src/main/java/com/nawabali/nawabali/domain/Post.java
@@ -1,6 +1,6 @@
 package com.nawabali.nawabali.domain;
 
-import com.nawabali.nawabali.constant.Address;
+
 import com.nawabali.nawabali.constant.Category;
 import com.nawabali.nawabali.constant.Town;
 import com.nawabali.nawabali.domain.image.PostImage;
@@ -8,8 +8,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.ErrorResponse;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/nawabali/nawabali/domain/elastic/PostSearch.java
+++ b/src/main/java/com/nawabali/nawabali/domain/elastic/PostSearch.java
@@ -1,0 +1,23 @@
+package com.nawabali.nawabali.domain.elastic;
+
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "post")
+@Getter @Setter
+public class PostSearch {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text)
+    private String contents;
+
+    @Field(type = FieldType.Long)
+    private Long postId;
+
+}

--- a/src/main/java/com/nawabali/nawabali/repository/elasticRepository/PostSearchRepository.java
+++ b/src/main/java/com/nawabali/nawabali/repository/elasticRepository/PostSearchRepository.java
@@ -1,0 +1,15 @@
+package com.nawabali.nawabali.repository.elasticRepository;
+
+import com.nawabali.nawabali.domain.Post;
+import com.nawabali.nawabali.domain.elastic.PostSearch;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostSearchRepository extends ElasticsearchRepository<PostSearch,Long> {
+    List<PostSearch> findByContentsContaining(String contents);
+    void deleteByPostId(Long postId);
+
+}

--- a/src/main/java/com/nawabali/nawabali/service/PostSearchService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostSearchService.java
@@ -1,0 +1,20 @@
+package com.nawabali.nawabali.service;
+
+import com.nawabali.nawabali.domain.elastic.PostSearch;
+import com.nawabali.nawabali.repository.elasticRepository.PostSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostSearchService {
+
+    private final PostSearchRepository postSearchRepository;
+
+    public List<PostSearch> searchByContents(String contents) {
+        return postSearchRepository.findByContentsContaining(contents);
+    }
+}
+


### PR DESCRIPTION
#### 구현 내용 - Elastic search 를 사용한 게시물 내용 검색
 1. b가 들어가는 게시물을 생성
<img width="903" alt="스크린샷 2024-04-05 오후 8 33 08" src="https://github.com/Nawabali-project/Nawabali-BE/assets/105621255/1efafe16-ae70-4243-b530-285b786919e0">

2. b를 검색하여 b로 시작하는 모든 게시물을 검색(현재는 하나밖에 생성을 안하여 한개만 나오지만 b로 시작하는 여러 게시물이 있을 시 다 검색이 되는 것을 확인)
<img width="573" alt="스크린샷 2024-04-05 오후 8 33 17" src="https://github.com/Nawabali-project/Nawabali-BE/assets/105621255/100f07a7-8fb9-479f-b67a-5bc7dc8f3ae3">


+ 간단히 Elastic search 검색 기능이 돌아가도록 구현, 추후 리펙토링이 필요함