### PR TITLE
게시물 상세조회시 반환내역 중 작성자 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -1,6 +1,5 @@
 package com.nawabali.nawabali.dto;
 
-import com.nawabali.nawabali.constant.Address;
 import com.nawabali.nawabali.constant.Category;
 import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.domain.image.PostImage;
@@ -9,7 +8,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -120,8 +118,10 @@ public class PostDto {
 
         private Long localLikesCount;
 
+        private String profileImageUrl;
 
-        public ResponseDetailDto(Post post, Long likesCount, Long localLikesCount) {
+
+        public ResponseDetailDto(Post post, Long likesCount, Long localLikesCount, String profileImageUrl) {
             this.userId = post.getUser().getId();
             this.postId = post.getId();
             this.nickname = post.getUser().getNickname();
@@ -136,6 +136,7 @@ public class PostDto {
             this.commentCount = post.getComments().size();
             this.likesCount = likesCount;
             this.localLikesCount = localLikesCount;
+            this.profileImageUrl = profileImageUrl;
         }
 
     }

--- a/src/main/java/com/nawabali/nawabali/repository/ProfileImageRepository.java
+++ b/src/main/java/com/nawabali/nawabali/repository/ProfileImageRepository.java
@@ -4,6 +4,9 @@ import com.nawabali.nawabali.domain.image.ProfileImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+    Optional<ProfileImage> findByUserId(Long id);
 }

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -6,6 +6,7 @@ import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.domain.User;
 import com.nawabali.nawabali.domain.elastic.PostSearch;
 import com.nawabali.nawabali.domain.image.PostImage;
+import com.nawabali.nawabali.domain.image.ProfileImage;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.dto.dslDto.PostDslDto;
 import com.nawabali.nawabali.exception.CustomException;
@@ -13,6 +14,7 @@ import com.nawabali.nawabali.exception.ErrorCode;
 import com.nawabali.nawabali.repository.LikeRepository;
 import com.nawabali.nawabali.repository.PostImageRepository;
 import com.nawabali.nawabali.repository.PostRepository;
+import com.nawabali.nawabali.repository.ProfileImageRepository;
 import com.nawabali.nawabali.repository.elasticRepository.PostSearchRepository;
 import com.nawabali.nawabali.s3.AwsS3Service;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,7 @@ public class PostService {
     private final UserService userService;
     private final AwsS3Service awsS3Service;
     private final PostSearchRepository postSearchRepository;
+    private final ProfileImageRepository profileImageRepository;
 
 
     // 게시물 생성
@@ -112,8 +115,9 @@ public class PostService {
         Post post = getPostId(postId);
         Long likesCount = getLikesCount(postId, LikeCategoryEnum.LIKE);
         Long localLikesCount = getLikesCount(postId, LikeCategoryEnum.LOCAL_LIKE);
+        String profileImageUrl = getProfileImage(postId).getImgUrl();
 
-        return new PostDto.ResponseDetailDto(post, likesCount, localLikesCount);
+        return new PostDto.ResponseDetailDto(post, likesCount, localLikesCount, profileImageUrl);
     }
 
     // 게시물 수정 - 사용자 신원 확인
@@ -157,6 +161,13 @@ public class PostService {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED_POST));
 
+    }
+
+    public ProfileImage getProfileImage(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        return profileImageRepository.findByUserId(post.getUser().getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PROFILEIMAGE_NOT_FOUND));
     }
 
 }


### PR DESCRIPTION
### 관련 이슈
* close #55 

### 변경사항
* 게시물 responseDto 내 프로필이미지 링크 추가

### 확인 요청사항
* 게시물 전체조회일 경우 작성자 프로필 이미지는 필요없는 것인지 확인 필요

### 포스트맨 확인
* getPost 결과
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/fa01e25a-73cb-446c-92a2-d5f634970c1f)
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/83fbbe0f-dcf0-4b69-af44-2bb1e44c7de2)
