### PR TITLE
전체 조회시 프로필이미지 반환

### DIFF
--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -72,6 +72,8 @@ public class PostDto {
 
         private int commentCount;
 
+        private String profileImageUrl;
+
 
         public ResponseDto(Post post) {
             this.userId = post.getUser().getId();
@@ -88,7 +90,6 @@ public class PostDto {
                     .map(PostImage::getImgUrl)
                     .collect(Collectors.toList());
             this.commentCount = post.getComments().size();
-
 
         }
 

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -94,6 +94,7 @@ public class PostService {
                 .map(post -> {
                     Long likesCount = getLikesCount(post.getPostId(), LIKE);
                     Long localLikesCount = getLikesCount(post.getPostId(), LikeCategoryEnum.LOCAL_LIKE);
+                    String profileImageUrl = getProfileImage(post.getPostId()).getImgUrl();
 
                     return new PostDto.ResponseDto(
                             post.getUserId(),
@@ -109,7 +110,8 @@ public class PostService {
                             post.getImageUrls(),
                             likesCount,
                             localLikesCount,
-                            post.getCommentCount()
+                            post.getCommentCount(),
+                            profileImageUrl
                     );
                 })
                 .collect(Collectors.toList());
@@ -135,6 +137,7 @@ public class PostService {
                 .map(post -> {
                     Long likesCount = getLikesCount(post.getPostId(), LIKE);
                     Long localLikesCount = getLikesCount(post.getPostId(), LikeCategoryEnum.LOCAL_LIKE);
+                    String profileImageUrl = getProfileImage(post.getPostId()).getImgUrl();
 
                     return new PostDto.ResponseDto(
                             post.getUserId(),
@@ -150,7 +153,8 @@ public class PostService {
                             post.getImageUrls(),
                             likesCount,
                             localLikesCount,
-                            post.getCommentCount()
+                            post.getCommentCount(),
+                            profileImageUrl
                     );
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
### 관련 이슈
* close #79   

### 변경사항
* ResponseDto에 프로필이미지 url 추가
* 게시물 전체 조회시 반환값에 프로필이미지 추가 반환
* 프로필이미지 업데이트 하지 않은 사용자는 디폴트 프로필이미지로 반환됨

### 포스트맨 확인
* getPosts
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/f31ac092-d657-4fdf-b12c-061a53e978e6)
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/149031461/5b12992b-5b40-4817-9557-8cfd73387c25)
