### PR TITLE
FIX : QueryDSL 메서드 분리 작업

### DIFF
--- a/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.nawabali.nawabali.controller;
 
+import com.nawabali.nawabali.constant.Category;
 import com.nawabali.nawabali.domain.elasticsearch.PostSearch;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.security.UserDetailsImpl;
@@ -74,7 +75,7 @@ public class PostController {
             })
     @GetMapping("/filtered")
     public ResponseEntity<Slice<PostDto.ResponseDto>> getPostByFiltered(
-            @RequestParam(required = false) String category,
+            @RequestParam(required = false) Category category,
             @RequestParam(required = false) String district,
             @PageableDefault(
                     size = 10,

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/bookmark/BookmarkDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/bookmark/BookmarkDslRepositoryCustomImpl.java
@@ -39,23 +39,42 @@ public class BookmarkDslRepositoryCustomImpl implements BookmarkDslRepositoryCus
             bookmarks.remove(bookmarks.size() - 1);
         }
 
-        List<BookmarkDslDto.UserBookmarkDto> responseDtos = bookmarks.stream()
-                .map(newBookmark -> BookmarkDslDto.UserBookmarkDto.builder()
-                        .userId(newBookmark.getUser().getId())
-                        .postId(newBookmark.getPost().getId())
-                        .nickname(newBookmark.getUser().getNickname())
-                        .contents(newBookmark.getPost().getContents())
-                        .category(newBookmark.getPost().getCategory().name())
-                        .district(newBookmark.getPost().getTown().getDistrict())
-                        .latitude(newBookmark.getPost().getTown().getLatitude())
-                        .longitude(newBookmark.getPost().getTown().getLongitude())
-                        .createdAt(newBookmark.getCreatedAt())
-                        .imageUrls(newBookmark.getPost().getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
-                        .commentCount(newBookmark.getPost().getComments().size())
-                        .build())
-                .collect(Collectors.toList());
+        List<BookmarkDslDto.UserBookmarkDto> responseDtos = convertBookmarkDto(bookmarks);
+//        bookmarks.stream()
+//                .map(newBookmark -> BookmarkDslDto.UserBookmarkDto.builder()
+//                        .userId(newBookmark.getUser().getId())
+//                        .postId(newBookmark.getPost().getId())
+//                        .nickname(newBookmark.getUser().getNickname())
+//                        .contents(newBookmark.getPost().getContents())
+//                        .category(newBookmark.getPost().getCategory().name())
+//                        .district(newBookmark.getPost().getTown().getDistrict())
+//                        .latitude(newBookmark.getPost().getTown().getLatitude())
+//                        .longitude(newBookmark.getPost().getTown().getLongitude())
+//                        .createdAt(newBookmark.getCreatedAt())
+//                        .imageUrls(newBookmark.getPost().getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
+//                        .commentCount(newBookmark.getPost().getComments().size())
+//                        .build())
+//                .collect(Collectors.toList());
 
         return new SliceImpl<>(responseDtos, pageable, hasNext);
+    }
+
+    private  List<BookmarkDslDto.UserBookmarkDto> convertBookmarkDto(List<BookMark> bookMarks) {
+        return bookMarks.stream()
+                .map(bookMark -> BookmarkDslDto.UserBookmarkDto.builder()
+                        .userId(bookMark.getUser().getId())
+                        .postId(bookMark.getPost().getId())
+                        .nickname(bookMark.getUser().getNickname())
+                        .contents(bookMark.getPost().getContents())
+                        .category(bookMark.getPost().getCategory().name())
+                        .district(bookMark.getPost().getTown().getDistrict())
+                        .latitude(bookMark.getPost().getTown().getLatitude())
+                        .longitude(bookMark.getPost().getTown().getLongitude())
+                        .createdAt(bookMark.getCreatedAt())
+                        .imageUrls(bookMark.getPost().getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
+                        .commentCount(bookMark.getPost().getComments().size())
+                        .build())
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/bookmark/BookmarkDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/bookmark/BookmarkDslRepositoryCustomImpl.java
@@ -40,24 +40,9 @@ public class BookmarkDslRepositoryCustomImpl implements BookmarkDslRepositoryCus
         }
 
         List<BookmarkDslDto.UserBookmarkDto> responseDtos = convertBookmarkDto(bookmarks);
-//        bookmarks.stream()
-//                .map(newBookmark -> BookmarkDslDto.UserBookmarkDto.builder()
-//                        .userId(newBookmark.getUser().getId())
-//                        .postId(newBookmark.getPost().getId())
-//                        .nickname(newBookmark.getUser().getNickname())
-//                        .contents(newBookmark.getPost().getContents())
-//                        .category(newBookmark.getPost().getCategory().name())
-//                        .district(newBookmark.getPost().getTown().getDistrict())
-//                        .latitude(newBookmark.getPost().getTown().getLatitude())
-//                        .longitude(newBookmark.getPost().getTown().getLongitude())
-//                        .createdAt(newBookmark.getCreatedAt())
-//                        .imageUrls(newBookmark.getPost().getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
-//                        .commentCount(newBookmark.getPost().getComments().size())
-//                        .build())
-//                .collect(Collectors.toList());
-
         return new SliceImpl<>(responseDtos, pageable, hasNext);
     }
+
 
     private  List<BookmarkDslDto.UserBookmarkDto> convertBookmarkDto(List<BookMark> bookMarks) {
         return bookMarks.stream()

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustom.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface PostDslRepositoryCustom {
 
     Slice<PostDslDto.ResponseDto> findPostsByLatest(Pageable pageable);
 
-    Slice<PostDslDto.ResponseDto> findCategoryByPost(String category, String district, Pageable pageable);
+    Slice<PostDslDto.ResponseDto> findCategoryByPost(Category category, String district, Pageable pageable);
     List<PostDslDto.SearchDto> findSearchByPosts(String contents);
 
     Slice<PostDto.ResponseDto> getMyPosts(Long userId, Pageable pageable, Category category);

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
@@ -50,23 +50,7 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
             posts.remove(posts.size() - 1);
         }
 
-        List<PostDslDto.ResponseDto> responseDtos = posts.stream()
-                .map(newPost -> PostDslDto.ResponseDto.builder()
-                        .userId(newPost.getUser().getId())
-                        .postId(newPost.getId())
-                        .nickname(newPost.getUser().getNickname())
-                        .contents(newPost.getContents())
-                        .category(newPost.getCategory().name())
-                        .district(newPost.getTown().getDistrict())
-                        .latitude(newPost.getTown().getLatitude())
-                        .longitude(newPost.getTown().getLongitude())
-                        .createdAt(newPost.getCreatedAt())
-                        .modifiedAt(newPost.getModifiedAt())
-                        .imageUrls(newPost.getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
-                        .commentCount(newPost.getComments().size())
-                        .build())
-                .collect(Collectors.toList());
-
+        List<PostDslDto.ResponseDto> responseDtos = convertPostDto(posts);
         return new SliceImpl<>(responseDtos, pageable, hasNext);
     }
 
@@ -104,23 +88,7 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
             posts.remove(posts.size() - 1);
         }
 
-        List<PostDslDto.ResponseDto> responseDtos = posts.stream()
-                .map(newPost -> PostDslDto.ResponseDto.builder()
-                        .userId(newPost.getUser().getId())
-                        .postId(newPost.getId())
-                        .nickname(newPost.getUser().getNickname())
-                        .contents(newPost.getContents())
-                        .category(newPost.getCategory().name())
-                        .district(newPost.getTown().getDistrict())
-                        .createdAt(newPost.getCreatedAt())
-                        .modifiedAt(newPost.getModifiedAt())
-                        .imageUrls(newPost.getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
-                        .commentCount(newPost.getComments().size())
-                        .latitude(newPost.getTown().getLatitude())
-                        .longitude(newPost.getTown().getLongitude())
-                        .build())
-                .collect(Collectors.toList());
-
+        List<PostDslDto.ResponseDto> responseDtos = convertPostDto(posts);
         return new SliceImpl<>(responseDtos, pageable, hasNext);
     }
 
@@ -129,8 +97,10 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         List<Post> posts= queryFactory
                 .selectFrom(post)
                 .leftJoin(post.user, user).fetchJoin()
-                .where(userEq(userId),
-                        categoryEq(category))
+                .where(
+                        userEq(userId),
+                        categoryEq(category)
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize()+1)
                 .orderBy(post.createdAt.desc())
@@ -144,10 +114,6 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         return new SliceImpl<>(posts, pageable, hasNext).map(PostDto.ResponseDto::new);
     }
 
-    // Category 조건
-//    private BooleanExpression categoryEq(String category) {
-//        return hasText(category) ? post.category.eq(Category.valueOf(category)) : null;
-//    }
 
     // District 조건
     private BooleanExpression districtEq(String district) {
@@ -171,5 +137,25 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
             return post.user.id.eq(userId);
         }
     }
+
+    private List<PostDslDto.ResponseDto> convertPostDto(List<Post> posts) {
+        return posts.stream()
+                .map(post -> PostDslDto.ResponseDto.builder()
+                        .userId(post.getUser().getId())
+                        .postId(post.getId())
+                        .nickname(post.getUser().getNickname())
+                        .contents(post.getContents())
+                        .category(post.getCategory().name())
+                        .district(post.getTown().getDistrict())
+                        .createdAt(post.getCreatedAt())
+                        .modifiedAt(post.getModifiedAt())
+                        .imageUrls(post.getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))
+                        .commentCount(post.getComments().size())
+                        .latitude(post.getTown().getLatitude())
+                        .longitude(post.getTown().getLongitude())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 
 }

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
@@ -88,7 +88,7 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
     }
 
     @Override
-    public Slice<PostDslDto.ResponseDto> findCategoryByPost(String category, String district, Pageable pageable) {
+    public Slice<PostDslDto.ResponseDto> findCategoryByPost(Category category, String district, Pageable pageable) {
         List<Post> posts = queryFactory
                 .selectFrom(post)
                 .leftJoin(post.user, user).fetchJoin()
@@ -145,10 +145,16 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
     }
 
     // Category 조건
-    private BooleanExpression categoryEq(String category) {
-        return hasText(category) ? post.category.eq(Category.valueOf(category)) : null;
+//    private BooleanExpression categoryEq(String category) {
+//        return hasText(category) ? post.category.eq(Category.valueOf(category)) : null;
+//    }
+
+    // District 조건
+    private BooleanExpression districtEq(String district) {
+        return hasText(district) ? post.town.district.eq(district) : null;
     }
 
+    // Category 조건
     private BooleanExpression categoryEq(Category category) {
         if(category==null){
             return null;
@@ -157,6 +163,7 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         }
     }
 
+    // user 조건
     private BooleanExpression userEq(Long userId){
         if(userId ==null){
             return null;
@@ -165,8 +172,4 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         }
     }
 
-    // District 조건
-    private BooleanExpression districtEq(String district) {
-        return hasText(district) ? post.town.district.eq(district) : null;
-    }
 }

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -1,5 +1,6 @@
 package com.nawabali.nawabali.service;
 
+import com.nawabali.nawabali.constant.Category;
 import com.nawabali.nawabali.constant.LikeCategoryEnum;
 import com.nawabali.nawabali.constant.Town;
 import com.nawabali.nawabali.domain.BookMark;
@@ -28,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -126,7 +128,7 @@ public class PostService {
     }
 
     // 카테고리 별 게시물 조회
-    public Slice<PostDto.ResponseDto> getPostByCategory(String category, String district, Pageable pageable) {
+    public Slice<PostDto.ResponseDto> getPostByCategory(Category category, String district, Pageable pageable) {
         Slice<PostDslDto.ResponseDto> postCategory = postRepository.findCategoryByPost(category,district, pageable);
         List<PostDto.ResponseDto> content = postCategory.getContent().stream()
                 .map(this::createPostDto)


### PR DESCRIPTION
1. QueryDSL 에서 코드를 단순화하고 메서드를 재사용 가능하도록 분리하는 작업을 진행하였습니다. 
각 엔티티를 dto 로 변환하는 로직을 메서드로 분리하였습니다. 

2. 또한 제가 작성하였던 categoryEq(String category) 메서드를 지우고 @juwum12  님이 작성하신 categoryEq(Category category) 메서드를 사용하기로 하였습니다.  
3. 그 이유는 
* enum 타입을 사용함으로 유효하지 않은 타입의 값 입력을 방지함으로 타입 안전성을 증가
* 문자열을 enum 으로 변환하는 작업을 하지 않아도 되어 추가 쿼리가 발생하지 않아 성능에 더 좋다
라는 이유로 그렇게 변경하였습니다.