### PR TITLE
FEAT : 최근 일주일간 작성된 게시글을 좋아요가 많은 순으로 상위 10개조회

### DIFF
--- a/src/main/java/com/nawabali/nawabali/constant/LikeCategoryEnum.java
+++ b/src/main/java/com/nawabali/nawabali/constant/LikeCategoryEnum.java
@@ -2,7 +2,6 @@ package com.nawabali.nawabali.constant;
 
 public enum LikeCategoryEnum {
     LIKE("LIKE"), LOCAL_LIKE("LOCAL_LIKE");
-    LikeCategoryEnum(String category){
-    }
+    LikeCategoryEnum(String category){}
 
 }

--- a/src/main/java/com/nawabali/nawabali/constant/Period.java
+++ b/src/main/java/com/nawabali/nawabali/constant/Period.java
@@ -1,0 +1,5 @@
+package com.nawabali.nawabali.constant;
+
+public enum Period {
+    WEEK, MONTH
+}

--- a/src/main/java/com/nawabali/nawabali/controller/LikeController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/LikeController.java
@@ -1,6 +1,7 @@
 package com.nawabali.nawabali.controller;
 
 import com.nawabali.nawabali.dto.LikeDto;
+import com.nawabali.nawabali.security.UserDetailsImpl;
 import com.nawabali.nawabali.service.LikeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "좋아요 API", description = "좋아요 관련 API 입니다.")
-
 @RestController
 @AllArgsConstructor
 @RequestMapping("/posts")
@@ -27,7 +27,7 @@ public class LikeController {
     @Operation(summary = "게시물 좋아요 생성 및 삭제", description = "postId 를 이용하여 토클 형태의 좋아요 클릭")
     @PatchMapping("/{postId}/likes")
     public LikeDto.responseDto toggleLike(@PathVariable("postId") Long postId,
-                                          @AuthenticationPrincipal UserDetails userDetails) {
+                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return likeService.toggleLike(postId, userDetails.getUsername());
     }
 

--- a/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.nawabali.nawabali.controller;
 
 import com.nawabali.nawabali.constant.Category;
+import com.nawabali.nawabali.constant.Period;
 import com.nawabali.nawabali.domain.elasticsearch.PostSearch;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.security.UserDetailsImpl;
@@ -100,10 +101,17 @@ public class PostController {
 
 
     @Operation(summary = "일주일 동안 좋아요 기준 상위 10개 게시물 조회",
-            description = "")
+               description =
+                       """
+                       category 또는 district 또는 기간(일주일,한달) 를 이용한 좋아요 기준 상위 10개 게시물을 조회
+                       * period 는 WEEK 와 MONTH 로 구분합니다.
+                       """)
     @GetMapping("/top-like")
-    public ResponseEntity<List<PostDto.ResponseDto>> getPostByLike() {
-        List<PostDto.ResponseDto> responseDto = postService.getPostByLike();
+    public ResponseEntity<List<PostDto.ResponseDto>> getPostByLike(
+            @RequestParam(required = false) Category category,
+            @RequestParam(required = false) String district,
+            @RequestParam(required = false) Period period) {
+        List<PostDto.ResponseDto> responseDto = postService.getPostByLike(category, district, period);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -99,6 +99,14 @@ public class PostController {
     }
 
 
+    @Operation(summary = "일주일 동안 좋아요 기준 상위 10개 게시물 조회",
+            description = "")
+    @GetMapping("/top-like")
+    public ResponseEntity<List<PostDto.ResponseDto>> getPostByLike() {
+        List<PostDto.ResponseDto> responseDto = postService.getPostByLike();
+        return ResponseEntity.ok(responseDto);
+    }
+
 
     @Operation(summary = "게시물 수정", description = "postId 를 이용한 게시물 수정")
     @PatchMapping("/{postId}")

--- a/src/main/java/com/nawabali/nawabali/exception/ErrorCode.java
+++ b/src/main/java/com/nawabali/nawabali/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     DISTRICTPOST_NOT_FOUND(NOT_FOUND, "해당 구의 총 게시물 수를 찾을 수 없습니다."),
     DISTRICTLIKE_NOT_FOUND(NOT_FOUND, "해당 구의 총 좋아요 수를 찾을 수 없습니다."),
     DISTRICTLOCALLIKE_NOT_FOUND(NOT_FOUND, "해당 구의 총 동네인증 수를 찾을 수 없습니다."),
+    PERIOD_NOT_FOUND(NOT_FOUND, "해당 기간을 찾을 수 없습니다(일주일 또는 한달만 가능합니다)."),
 
     // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)
     DUPLICATE_EMAIL(CONFLICT, "이미 존재하는 이메일입니다."),

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustom.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustom.java
@@ -16,6 +16,8 @@ public interface PostDslRepositoryCustom {
     Slice<PostDslDto.ResponseDto> findCategoryByPost(Category category, String district, Pageable pageable);
     List<PostDslDto.SearchDto> findSearchByPosts(String contents);
 
+    List<PostDslDto.ResponseDto> topLikeByPosts();
+
     Slice<PostDto.ResponseDto> getMyPosts(Long userId, Pageable pageable, Category category);
 
 }

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustom.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.nawabali.nawabali.repository.querydsl.post;
 
 import com.nawabali.nawabali.constant.Category;
+import com.nawabali.nawabali.constant.Period;
 import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.dto.querydsl.PostDslDto;
@@ -16,7 +17,7 @@ public interface PostDslRepositoryCustom {
     Slice<PostDslDto.ResponseDto> findCategoryByPost(Category category, String district, Pageable pageable);
     List<PostDslDto.SearchDto> findSearchByPosts(String contents);
 
-    List<PostDslDto.ResponseDto> topLikeByPosts();
+    List<PostDslDto.ResponseDto> topLikeByPosts(Category category, String district, Period period);
 
     Slice<PostDto.ResponseDto> getMyPosts(Long userId, Pageable pageable, Category category);
 

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.nawabali.nawabali.repository.querydsl.post;
 
 import com.nawabali.nawabali.constant.Category;
+import com.nawabali.nawabali.constant.Period;
 import com.nawabali.nawabali.domain.Post;
 import com.nawabali.nawabali.domain.QLike;
 import com.nawabali.nawabali.domain.QPost;
@@ -8,6 +9,8 @@ import com.nawabali.nawabali.domain.QUser;
 import com.nawabali.nawabali.domain.image.PostImage;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.dto.querydsl.PostDslDto;
+import com.nawabali.nawabali.exception.CustomException;
+import com.nawabali.nawabali.exception.ErrorCode;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -100,17 +103,21 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
 
     // 일주일 동안 좋아요 기준 상위 10개 게시물 조회
     @Override
-    public List<PostDslDto.ResponseDto> topLikeByPosts() {
+    public List<PostDslDto.ResponseDto> topLikeByPosts(Category category, String district, Period period) {
         QPost post = QPost.post;
         QUser user = QUser.user;
         QLike like = QLike.like;
-        LocalDateTime oneWeekPost = LocalDateTime.now().minusWeeks(1);  // 일주일 계산
+
 
         List<Post> posts = queryFactory
                 .selectFrom(post)
                 .leftJoin(post.user,user).fetchJoin()
                 .leftJoin(post.likes,like)
-                .where(post.createdAt.after(oneWeekPost))
+                .where(
+                        periodEq(period),
+                        categoryEq(category),
+                        districtEq(district)
+                )
                 .groupBy(post.id)
                 .orderBy(
                         like.count().desc(),
@@ -162,6 +169,22 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         }else{
             return post.category.eq(category);
         }
+    }
+
+    // 일주일 또는 한달 기간 조건
+    private BooleanExpression periodEq(Period period) {
+        if(period == null) {
+            return null;
+        }
+
+        LocalDateTime end  = LocalDateTime.now();
+        LocalDateTime start = switch (period) {
+            case WEEK -> end.minusWeeks(1);
+            case MONTH -> end.minusMonths(1);
+            default -> throw new CustomException(ErrorCode.PERIOD_NOT_FOUND);
+        };
+
+        return post.createdAt.between(start, end);
     }
 
     // user 조건

--- a/src/main/java/com/nawabali/nawabali/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/nawabali/nawabali/security/UserDetailsServiceImpl.java
@@ -13,18 +13,11 @@ import org.springframework.stereotype.Service;
 public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
 
-    //    @Override
-//    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-//        User user = userRepository.findByEmail(email);
-//        if(user==null){
-//            throw new UsernameNotFoundException("Not Found " + email);
-//        }
-//        return new UserDetailsImpl(user);
-//    }
+
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저의 이메일 정보를 찾을 수 없습니다 : " + email));
 
         return new UserDetailsImpl(user);
     }

--- a/src/main/java/com/nawabali/nawabali/service/LikeService.java
+++ b/src/main/java/com/nawabali/nawabali/service/LikeService.java
@@ -52,9 +52,7 @@ public class LikeService {
                     .status(findLike.isStatus())
                     .message("좋아요 취소 되었습니다.")
                     .build();
-        }
-
-        else{
+        }  else{
             // 내역에 없디면 추가.
             findLike = Like.builder()
                     .user(user)
@@ -88,7 +86,7 @@ public class LikeService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-//         해당 지역의 회원인지 확인
+        // 해당 지역의 회원인지 확인
         if(!isMatchDistrict(user, post)){
             throw new CustomException(ErrorCode.MISMATCH_ADDRESS);
         }

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -138,6 +138,17 @@ public class PostService {
     }
 
 
+    // 최근 일주일간 작성된 게시글을 좋아요가 많은 순으로 상위 10개
+    public List<PostDto.ResponseDto> getPostByLike() {
+        //topLikeByPosts
+        List<PostDslDto.ResponseDto> posts = postRepository.topLikeByPosts();
+
+        // PostDslDto.ResponseDto를 PostDto.ResponseDto로 변환
+        return posts.stream()
+                .map(this::createPostDto)
+                .collect(Collectors.toList());
+    }
+
     // 게시물 수정 - 사용자 신원 확인
     @Transactional
     public PostDto.PatchDto updatePost(Long postId, User user, PostDto.PatchDto patchDto) {

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -159,7 +159,7 @@ public class PostService {
         postRepository.save(post);
 
         // es 업데이트
-        PostSearch existingPostSearch = postSearchRepository.findById(Long.valueOf(postId.toString()))
+        PostSearch existingPostSearch = postSearchRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("es 문서를 찾을 수 없음"));
         existingPostSearch.setContents(post.getContents());
 

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -2,6 +2,7 @@ package com.nawabali.nawabali.service;
 
 import com.nawabali.nawabali.constant.Category;
 import com.nawabali.nawabali.constant.LikeCategoryEnum;
+import com.nawabali.nawabali.constant.Period;
 import com.nawabali.nawabali.constant.Town;
 import com.nawabali.nawabali.domain.BookMark;
 import com.nawabali.nawabali.domain.Like;
@@ -139,9 +140,9 @@ public class PostService {
     }
 
 
-    // 최근 일주일간 작성된 게시글을 좋아요가 많은 순으로 상위 10개
-    public List<PostDto.ResponseDto> getPostByLike() {
-        List<PostDslDto.ResponseDto> posts = postRepository.topLikeByPosts();
+    // 작성된 게시글을 좋아요가 많은 순으로 상위 10개( 카테고리, 구, 기간 으로 필터링 )
+    public List<PostDto.ResponseDto> getPostByLike(Category category, String district, Period period) {
+        List<PostDslDto.ResponseDto> posts = postRepository.topLikeByPosts(category,district, period);
         return posts.stream()
                 .map(this::createPostDto)
                 .collect(Collectors.toList());


### PR DESCRIPTION
### <PR 사항 - 변경 >

< 기존 PR 내용 >

> - 프론트쪽에서 최근 일주일간 작성된 게시글을 좋아요가 많은 순으로 상위 10개조회하는 API 요청을 하셔서 해당 사항 구현하였습니다.
> - 상위 10개만 조회하므로 List 로 반환하였습니다. 만약 게시물이 10개인데 3개만 좋아요가 있고 나머지 7개 게시물의 좋아요가 0개일 경우라면 0개인 경우도 조회목록에 포함시켰습니다. 
> - 게시물 ID 기준으로 groupby 하여서 id 로 그룹화 시켜 계산하였습니다.

< 변경사항 >
-   금일 회의 때 나온 의견을 반영하여 구 ,카테고리, 최근 일주일(또는 한달) 이내 해당하는 게시글들을 좋아요 순으로 10개 조회하는 방법으로 수정하였습니다. ( 기간은 enum 타입 -> WEEK , MONTH 로 일주일 또는 한달 선택 가능)

<img width="891" alt="스크린샷 2024-04-17 오후 10 19 22" src="https://github.com/Nawabali-project/Nawabali-BE/assets/105621255/8ddf9456-9470-4804-be83-5f3a3623ece4">

