### PR TITLE
FIX : 채팅방 내용 조회시 thymeleaf 에러 해결

### DIFF
--- a/src/main/java/com/nawabali/nawabali/controller/ChatRoomController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/ChatRoomController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -71,8 +72,9 @@ public class ChatRoomController {
 
     @Operation(summary = "채팅방 대화 내용 조회" , description = "채팅방 전제 대화 내용 조회 API")
     @GetMapping("/room/{roomId}/message")
-    public List<ChatDto.ChatMessageDto> loadMessage (@PathVariable Long roomId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return chatRoomService.loadMessage(roomId, userDetails.getUser());
-    }  // ChatController는 웹소켓 endpoint를 담당해서 일반적인 http요청을 처리하지 않아 이곳으로 옮겨 놓음.
+    public ResponseEntity<List<ChatDto.ChatMessageDto>> loadMessage (@PathVariable Long roomId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<ChatDto.ChatMessageDto> messages = chatRoomService.loadMessage(roomId, userDetails.getUser());
+        return ResponseEntity.ok(messages);
+    }
 
 }

--- a/src/main/java/com/nawabali/nawabali/service/ChatRoomService.java
+++ b/src/main/java/com/nawabali/nawabali/service/ChatRoomService.java
@@ -136,6 +136,14 @@ public class ChatRoomService {
         List<Chat.ChatMessage> chatMessages = chatMessageRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
                 .orElseThrow(()-> new CustomException(ErrorCode.FORBIDDEN_CHATMESSAGE));
 
+        if (chatMessages.isEmpty()) {
+            return Collections.singletonList(
+                    ChatDto.ChatMessageDto.builder()
+                            .message("채팅방에 메세지가 존재하지 않습니다.")
+                            .build()
+            );
+        }
+
         // ChatMessage를 ChatDto.ChatMessage로 변환하여 반환
         return chatMessages.stream()
                 .map(chatMessage -> ChatDto.ChatMessageDto.builder()


### PR DESCRIPTION
채팅방 내용 조회시 thymeleaf 오류 발생
-> Spring MVC에서 Thymeleaf 뷰 리졸버가 자동으로 작동하여 템플릿을 찾으려고 시도하기 때문에 발생한걸로 예상
-> @ResponseBody 어노테이션을 사용하여 데이터를 직접 반환하도록 수정하여 해결

& 메세지가 존재하지 않으면 null 값과 "채팅방에 메세지가 존재하지 않습니다" 메세지 보내기

<img width="1728" alt="스크린샷 2024-04-18 오전 12 03 53" src="https://github.com/Nawabali-project/Nawabali-BE/assets/157681548/d59c26d1-9e86-4e21-bee3-652145ca75cb">
