### PR TITLE
닉네임 검색 API 추가

### DIFF
--- a/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -87,7 +87,7 @@ public class UserController {
     }
 
     @GetMapping("/search")
-    public List<UserSearch> searchNickname(@RequestParam(name = "nickname") String nickname){
+    public List<UserSearch> searchNickname(@RequestParam(name = "nickname", required = false) String nickname){
         return userService.searchNickname(nickname);
     }
 

--- a/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -2,6 +2,7 @@ package com.nawabali.nawabali.controller;
 
 
 import com.nawabali.nawabali.constant.Category;
+import com.nawabali.nawabali.domain.elasticsearch.UserSearch;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.dto.SignupDto;
 import com.nawabali.nawabali.dto.UserDto;
@@ -21,6 +22,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -81,6 +84,11 @@ public class UserController {
             @RequestParam(name ="category",required = false) Category category)
     {
         return userService.getMyPosts(userDetails.getUser(), pageable, category);
+    }
+
+    @GetMapping("/search")
+    public List<UserSearch> searchNickname(@RequestParam(name = "nickname") String nickname){
+        return userService.searchNickname(nickname);
     }
 
 

--- a/src/main/java/com/nawabali/nawabali/domain/elasticsearch/UserSearch.java
+++ b/src/main/java/com/nawabali/nawabali/domain/elasticsearch/UserSearch.java
@@ -1,0 +1,32 @@
+package com.nawabali.nawabali.domain.elasticsearch;
+
+import com.nawabali.nawabali.domain.User;
+import com.nawabali.nawabali.dto.UserDto;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "users")
+public class UserSearch {
+    @Id
+    private String id;
+    @Field(type = FieldType.Text)
+    private String nickname;
+    @Field(type=FieldType.Text)
+    private String imgUrl;
+
+
+    public UserSearch(User user, String imgUrl) {
+        this.id = user.getId().toString();
+        this.nickname = user.getNickname();
+        this.imgUrl = imgUrl;
+    }
+}

--- a/src/main/java/com/nawabali/nawabali/dto/UserDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/UserDto.java
@@ -102,19 +102,4 @@ public class UserDto {
         private String message;
     }
 
-
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class kakaoLoginResponseDto {
-        @Schema(description = "유저의 pk")
-        private Long id;
-        @Schema(description = "소셜로그인 메세지", example = "소셜 로그인이 완료되었습니다.")
-        private String msg = "로그인 성공";
-
-        public kakaoLoginResponseDto(Long id) {
-            this.id = id;
-        }
-    }
 }

--- a/src/main/java/com/nawabali/nawabali/repository/elasticsearch/UserSearchRepository.java
+++ b/src/main/java/com/nawabali/nawabali/repository/elasticsearch/UserSearchRepository.java
@@ -1,0 +1,11 @@
+package com.nawabali.nawabali.repository.elasticsearch;
+
+import com.nawabali.nawabali.domain.elasticsearch.UserSearch;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface UserSearchRepository extends ElasticsearchRepository<UserSearch, Long> {
+    List<UserSearch> findByNicknameContaining(String nickname);
+    void deleteByNickname(String nickname);
+}

--- a/src/main/java/com/nawabali/nawabali/service/UserService.java
+++ b/src/main/java/com/nawabali/nawabali/service/UserService.java
@@ -188,6 +188,9 @@ public class UserService {
     }
 
     public List<UserSearch> searchNickname(String nickname) {
+        if(!StringUtils.hasText(nickname)){
+            return null;
+        }
         return userSearchRepository.findByNicknameContaining(nickname);
     }
 

--- a/src/main/java/com/nawabali/nawabali/service/UserService.java
+++ b/src/main/java/com/nawabali/nawabali/service/UserService.java
@@ -2,6 +2,7 @@ package com.nawabali.nawabali.service;
 
 import com.nawabali.nawabali.constant.*;
 import com.nawabali.nawabali.domain.User;
+import com.nawabali.nawabali.domain.elasticsearch.UserSearch;
 import com.nawabali.nawabali.domain.image.ProfileImage;
 import com.nawabali.nawabali.dto.PostDto;
 import com.nawabali.nawabali.dto.SignupDto;
@@ -13,6 +14,7 @@ import com.nawabali.nawabali.repository.LikeRepository;
 import com.nawabali.nawabali.repository.PostRepository;
 import com.nawabali.nawabali.repository.ProfileImageRepository;
 import com.nawabali.nawabali.repository.UserRepository;
+import com.nawabali.nawabali.repository.elasticsearch.UserSearchRepository;
 import com.nawabali.nawabali.security.Jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,7 @@ public class UserService {
 
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
+    private final UserSearchRepository userSearchRepository;
     private final JwtUtil jwtUtil;
     private final RedisTool redisTool;
 
@@ -81,7 +84,6 @@ public class UserService {
 
         String password = passwordEncoder.encode(rawPassword);
 
-
         // 관리자 권한 부여
         UserRoleEnum role = UserRoleEnum.USER;
 //        if(requestDto.isAdmin()){
@@ -109,6 +111,10 @@ public class UserService {
         profileImageRepository.save(profileImage);
         User responseUser = userRepository.findByEmail(user.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        UserSearch userSearch = new UserSearch(responseUser, profileImage.getImgUrl());
+        userSearchRepository.save(userSearch);
+
         return ResponseEntity.ok(new SignupDto.SignupResponseDto(responseUser.getId()));
     }
 
@@ -147,6 +153,9 @@ public class UserService {
         requestDto.setPassword(password);
 
         existUser.update(requestDto);
+
+        UserSearch userSearch = new UserSearch(existUser, existUser.getProfileImage().getImgUrl());
+        userSearchRepository.save(userSearch);
         return new UserDto.UserInfoResponseDto(existUser);
     }
 
@@ -155,6 +164,7 @@ public class UserService {
         User existUser = getUserId(user.getId());
 
         userRepository.delete(existUser);
+        userSearchRepository.deleteById(existUser.getId());
         return ResponseEntity.ok(new UserDto.deleteResponseDto());
     }
 
@@ -175,6 +185,10 @@ public class UserService {
                 .toList();
 
         return new SliceImpl<>(posts, pageable, rawPosts.hasNext());
+    }
+
+    public List<UserSearch> searchNickname(String nickname) {
+        return userSearchRepository.findByNicknameContaining(nickname);
     }
 
     // 메서드 //
@@ -200,11 +214,11 @@ public class UserService {
         return likeRepository.countByPostIdInAndLikeCategoryEnum(postIds, likeCategoryEnum);
     }
 
-    public Long getLikesCount(Long postId, LikeCategoryEnum likeCategoryEnum){
+    public Long getLikesCount(Long postId, LikeCategoryEnum likeCategoryEnum) {
         return likeRepository.countByPostIdAndLikeCategoryEnum(postId, likeCategoryEnum);
     }
 
-    public List<Long> getMyPostIds(Long userId){
+    public List<Long> getMyPostIds(Long userId) {
         return postRepository.findByUserId(userId).stream()
                 .map(PostDto.getMyPostsResponseDto::getId)
                 .toList();


### PR DESCRIPTION
닉네임 검색 API 추가했습니다.
반환값은  유저의PK, 닉네임, 프로필이미지입니다.
서버 부하를 줄이기 위해 닉네임 전체조회는 제외했습니다(쿼리가 없을 때 null 반환).

**일부 검색**
![스크린샷 2024-04-18 192437](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/04e19066-91ef-4400-bb59-53efb9e215e2)
*빈칸 일 때 null 반환*
![image](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/c9256659-8efa-49a5-8c12-30b7b4e77483)


