### PR TITLE
FIX : 로그아웃, 내정보 API 수정

### DIFF
--- a/src/main/java/com/nawabali/nawabali/constant/UserRankEnum.java
+++ b/src/main/java/com/nawabali/nawabali/constant/UserRankEnum.java
@@ -4,9 +4,17 @@ import lombok.Getter;
 
 @Getter
 public enum UserRankEnum {
-    RESIDENT("RESIDENT"),
-    NATIVE_PERSON("NATIVE_PERSON"),
-    LOCAL_ELDER("LOCAL_ELDER");
+    RESIDENT("주민",5L,0L),
+    NATIVE_PERSON("토박이",10L,100L),
+    LOCAL_ELDER("터줏대감",0L,0L);
 
-    UserRankEnum(String rank) {}
+    private final String name;
+    private final Long needPosts;
+    private final Long needLikes;
+
+    UserRankEnum(String name, Long needPosts, Long needTotalLikes) {
+        this.name = name;
+        this.needPosts = needPosts;
+        this.needLikes = needTotalLikes;
+    }
 }

--- a/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -34,8 +34,8 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response){
-        return userService.logout(request, response);
+    public ResponseEntity<String> logout(@RequestParam(name = "accessToken", required = false) String accessToken){
+        return userService.logout(accessToken);
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -47,7 +47,7 @@ public class PostDto {
 
         private Long userId;
 
-        private UserRankEnum userRank;
+        private String userRankName;
 
         private Long postId;
 
@@ -80,7 +80,7 @@ public class PostDto {
 
         public ResponseDto(Post post, Long likesCount, Long localLikesCount, String profileImageUrl) {
             this.userId = post.getUser().getId();
-            this.userRank = post.getUser().getRank();
+            this.userRankName = post.getUser().getRank().getName();
             this.postId = post.getId();
             this.nickname = post.getUser().getNickname();
             this.contents = post.getContents();
@@ -102,7 +102,7 @@ public class PostDto {
 
         public ResponseDto(Post post) {
             this.userId = post.getUser().getId();
-            this.userRank = post.getUser().getRank();
+            this.userRankName = post.getUser().getRank().name();
             this.postId = post.getId();
             this.nickname = post.getUser().getNickname();
             this.contents = post.getContents();
@@ -128,7 +128,7 @@ public class PostDto {
 
         private Long userId;
 
-        private UserRankEnum userRank;
+        private String userRankName;
 
         private Long postId;
 
@@ -161,7 +161,7 @@ public class PostDto {
 
         public ResponseDetailDto(Post post, Long likesCount, Long localLikesCount, String profileImageUrl, boolean likeStatus, boolean localLikesStatus, boolean bookmarkStatus) {
             this.userId = post.getUser().getId();
-            this.userRank=post.getUser().getRank();
+            this.userRankName=post.getUser().getRank().getName();
             this.postId = post.getId();
             this.nickname = post.getUser().getNickname();
             this.contents = post.getContents();

--- a/src/main/java/com/nawabali/nawabali/dto/UserDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/UserDto.java
@@ -26,11 +26,12 @@ public class UserDto {
         String nickname;
         String city;
         String district;
-        UserRankEnum rank;
+        String rankName;
         Long totalLikesCount;
         Long totalLocalLikesCount;
         String profileImageUrl;
-
+        Long needPosts;
+        Long needLikes;
 
         public UserInfoResponseDto(User user) {
             this.id = user.getId();
@@ -38,8 +39,20 @@ public class UserDto {
             this.nickname = user.getNickname();
             this.city = user.getAddress().getCity();
             this.district = user.getAddress().getDistrict();
-            this.rank = user.getRank();
+            this.rankName = user.getRank().name();
             this.profileImageUrl = user.getProfileImage().getImgUrl();
+        }
+
+        public UserInfoResponseDto(User user, Long needPosts, Long needLikes) {
+            this.id = user.getId();
+            this.email = user.getEmail();
+            this.nickname = user.getNickname();
+            this.city = user.getAddress().getCity();
+            this.district = user.getAddress().getDistrict();
+            this.rankName = user.getRank().name();
+            this.profileImageUrl = user.getProfileImage().getImgUrl();
+            this.needPosts = needPosts;
+            this.needLikes = needLikes;
         }
     }
 

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
@@ -223,7 +223,7 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         return posts.stream()
                 .map(post -> PostDto.ResponseDto.builder()
                         .userId(post.getUser().getId())
-                        .userRank(post.getUser().getRank())
+                        .userRankName(post.getUser().getRank().getName())
                         .postId(post.getId())
                         .nickname(post.getUser().getNickname())
                         .contents(post.getContents())

--- a/src/main/java/com/nawabali/nawabali/security/Jwt/JwtUtil.java
+++ b/src/main/java/com/nawabali/nawabali/security/Jwt/JwtUtil.java
@@ -41,7 +41,7 @@ public class JwtUtil {
     // 로그 설정
     public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
     // 토큰 만료 시간
-    private final int ACCESS_EXPIRATION_TIME = 10 * 1000; // 60분
+    private final int ACCESS_EXPIRATION_TIME = 60 * 60 * 1000; // 60분
     public final int REFRESH_EXPIRATION_TIME = 24 * 60 * 60 * 1000; // 24시간
 
     @PostConstruct

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -265,7 +265,7 @@ public class PostService {
 
         return new PostDto.ResponseDto(
                 post.getUserId(),
-                post.getUserRank(),
+                post.getUserRankName(),
                 post.getPostId(),
                 post.getNickname(),
                 post.getContents(),


### PR DESCRIPTION
-로그아웃 로직 변경
헤더에서 토큰을 받는 방식에서 Param으로 토큰값을 받는 방법으로 바꿨습니다.

-UserRankEnum수정
반환 값을 한글로 전달하기 위하여 한글 명을 추가하고, 다음 등급까지 필요한 정보(총 게시글, 좋아요)를 등급안에 담았습니다.

-내 정보 api 수정
기존 반환값에 유저의 등급을 한글로 반환하고, 다음 등급까지 남은 게시글과 총 좋아요 개수를 반환에 추가했습니다.
내 정보 변경시 비밀번호를 반드시 입력할 필요가 없도록 수정했습니다.

-게시글 조회 반환 값 수정
기존 반환 값에 유저의 등급을 추가했습니다.

**내 정보 조회**
![스크린샷 2024-04-20 005711](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/93328644-58b8-4b29-8410-08d44a856fc1)

**게시글 조회 시 반환 값 수정**
![스크린샷 2024-04-20 010557](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/3e43dd91-db28-46f2-88d5-96f709fff42f)

**상세 조회시 반환 값 수정**
![스크린샷 2024-04-20 010629](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/7ffe62cc-78c8-421f-b364-ce525743ff25)
