### PR TITLE
FIX : 게시물 API 요청값 및 반환값 수정

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,28 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="springboot-database" uuid="1845f1a1-5840-4312-bbde-3b752e7c5b3a">
-      <driver-ref>mysql.8</driver-ref>
-      <synchronize>true</synchronize>
-      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
-      <jdbc-url>jdbc:mysql://springboot-database.cbe6ouewo4p0.ap-northeast-2.rds.amazonaws.com:3306/sparta</jdbc-url>
-      <jdbc-additional-properties>
-        <property name="com.intellij.clouds.kubernetes.db.host.port" />
-        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
-        <property name="com.intellij.clouds.kubernetes.db.container.port" />
-      </jdbc-additional-properties>
-      <working-dir>$ProjectFileDir$</working-dir>
-    </data-source>
-    <data-source source="LOCAL" name="nawabali@localhost" uuid="79a463fb-4756-44b9-8283-8dce39f4a4b4">
+    <data-source source="LOCAL" name="nawabali@localhost" uuid="25e6fdec-1181-4fd4-800e-b70f71820b25">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
       <jdbc-url>jdbc:mysql://localhost:3306/nawabali</jdbc-url>
-      <jdbc-additional-properties>
-        <property name="com.intellij.clouds.kubernetes.db.host.port" />
-        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
-        <property name="com.intellij.clouds.kubernetes.db.container.port" />
-      </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
   </component>

--- a/src/main/generated/com/nawabali/nawabali/constant/QTown.java
+++ b/src/main/generated/com/nawabali/nawabali/constant/QTown.java
@@ -25,6 +25,10 @@ public class QTown extends BeanPath<Town> {
 
     public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
 
+    public final StringPath placeAddr = createString("placeAddr");
+
+    public final StringPath placeName = createString("placeName");
+
     public QTown(String variable) {
         super(Town.class, forVariable(variable));
     }

--- a/src/main/java/com/nawabali/nawabali/constant/Town.java
+++ b/src/main/java/com/nawabali/nawabali/constant/Town.java
@@ -12,12 +12,19 @@ public class Town {
     private Double longitude;    // 경도
 
     private String district;    // 구
+
+    private String placeName;
+
+    private String placeAddr;
+
     protected Town() {}  //무분별한 생성을 막기 위해 protected 로 선언
 
     // 필요시 추가 생성자 필요
-    public Town(Double latitude, Double longitude, String district) {
+    public Town(Double latitude, Double longitude, String district, String placeName, String placeAddr) {
         this.latitude = latitude;
         this.longitude = longitude;
         this.district = district;
+        this.placeName = placeName;
+        this.placeAddr = placeAddr;
     }
 }

--- a/src/main/java/com/nawabali/nawabali/controller/PostController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/PostController.java
@@ -129,6 +129,11 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "구 와 한달기준 각 카테고리의 게시글 개수를 출력",
+            description =
+                    """
+                    district 로 한달간 각 카테고리의 게시글 수를 출력합니다.
+                    """)
     @GetMapping("/sort-category")
     public ResponseEntity<List<PostDto.SortCategoryDto>> getCategoryByPost(
             @RequestParam(required = false) String district

--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -65,6 +65,10 @@ public class PostDto {
 
         private String district;
 
+        private String placeName;
+
+        private String placeAddr;
+
         private Double latitude;
 
         private Double longitude;
@@ -92,6 +96,8 @@ public class PostDto {
             this.contents = post.getContents();
             this.category = post.getCategory().name();
             this.district = post.getTown().getDistrict();
+            this.placeName = post.getTown().getPlaceName();
+            this.placeAddr = post.getTown().getPlaceAddr();
             this.latitude = post.getTown().getLatitude();
             this.longitude = post.getTown().getLongitude();
             this.createdAt = post.getCreatedAt();
@@ -160,6 +166,10 @@ public class PostDto {
 
         private String district;
 
+        private String placeName;
+
+        private String placeAddr;
+
         private boolean likeStatus;
         private boolean localLikeStatus;
         private boolean bookmarkStatus;
@@ -182,6 +192,8 @@ public class PostDto {
             this.localLikesCount = localLikesCount;
             this.profileImageUrl = profileImageUrl;
             this.district = post.getTown().getDistrict();
+            this.placeName = post.getTown().getPlaceName();
+            this.placeAddr = post.getTown().getPlaceAddr();
             this.likeStatus = likeStatus;
             this.localLikeStatus = localLikesStatus;
             this.bookmarkStatus = bookmarkStatus;

--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -36,6 +36,12 @@ public class PostDto {
         @NotNull
         private String district;
 
+        @NotNull
+        private String placeName;
+
+        @NotNull
+        private String placeAddr;
+
     }
 
     @Getter

--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -266,6 +266,6 @@ public class PostDto {
     @Builder
     public static class SortCategoryDto {
         private String category;
-        private Long postCount = 0L;
+        private Long postCount;
     }
 }

--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -120,6 +120,8 @@ public class PostDto {
             this.contents = post.getContents();
             this.category = post.getCategory().name();
             this.district = post.getTown().getDistrict();
+            this.placeName = post.getTown().getPlaceName();
+            this.placeAddr = post.getTown().getPlaceAddr();
             this.latitude = post.getTown().getLatitude();
             this.longitude = post.getTown().getLongitude();
             this.createdAt = post.getCreatedAt();

--- a/src/main/java/com/nawabali/nawabali/dto/PostDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/PostDto.java
@@ -36,7 +36,6 @@ public class PostDto {
         @NotNull
         private String district;
 
-        @NotNull
         private String placeName;
 
         @NotNull

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
@@ -156,7 +156,7 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
         return results;
     }
 
-    // 구 와 기간별 각 카테고리의 게시글 개수
+    // 구 와 한달기준 각 카테고리의 게시글 개수
     @Override
     public List<PostDto.SortCategoryDto> findCategoryByPost(String district) {
         QPost post = QPost.post;

--- a/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
+++ b/src/main/java/com/nawabali/nawabali/repository/querydsl/post/PostDslRepositoryCustomImpl.java
@@ -116,8 +116,8 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
 
         List<Post> posts = queryFactory
                 .selectFrom(post)
-                .leftJoin(post.user,user).fetchJoin()
-                .leftJoin(post.likes,like).fetchJoin()
+                .leftJoin(post.user,user)
+                .leftJoin(post.likes,like)
                 .where(
                         periodEq(period),
                         categoryEq(category),
@@ -262,6 +262,8 @@ public class PostDslRepositoryCustomImpl implements PostDslRepositoryCustom{
                         .contents(post.getContents())
                         .category(post.getCategory().name())
                         .district(post.getTown().getDistrict())
+                        .placeName(post.getTown().getPlaceName())
+                        .placeAddr(post.getTown().getPlaceAddr())
                         .createdAt(post.getCreatedAt())
                         .modifiedAt(post.getModifiedAt())
                         .imageUrls(post.getImages().stream().map(PostImage::getImgUrl).collect(Collectors.toList()))

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -173,6 +173,8 @@ public class PostService {
         return postRepository.findDistrictByPost(category, period);
     }
 
+
+    // 구 와 한달기준 각 카테고리의 게시글 개수
     public List<PostDto.SortCategoryDto> getCategoryByPost(String district) {
         return postRepository.findCategoryByPost(district);
     }

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -295,6 +295,8 @@ public class PostService {
                 post.getContents(),
                 post.getCategory(),
                 post.getDistrict(),
+                post.getPlaceName(),
+                post.getPlaceAddr(),
                 post.getLatitude(),
                 post.getLongitude(),
                 post.getCreatedAt(),

--- a/src/main/java/com/nawabali/nawabali/service/PostService.java
+++ b/src/main/java/com/nawabali/nawabali/service/PostService.java
@@ -63,7 +63,9 @@ public class PostService {
         Town town = new Town(
                 requestDto.getLatitude(),
                 requestDto.getLongitude(),
-                requestDto.getDistrict()
+                requestDto.getDistrict(),
+                requestDto.getPlaceName(),
+                requestDto.getPlaceAddr()
         );
 
         Post post = Post.builder()

--- a/src/test/java/com/nawabali/nawabali/service/PostServiceTest.java
+++ b/src/test/java/com/nawabali/nawabali/service/PostServiceTest.java
@@ -1,0 +1,106 @@
+package com.nawabali.nawabali.service;
+
+import com.nawabali.nawabali.constant.Category;
+import com.nawabali.nawabali.constant.Period;
+import com.nawabali.nawabali.dto.PostDto;
+import com.nawabali.nawabali.repository.PostRepository;
+import com.nawabali.nawabali.repository.elasticsearch.PostSearchRepository;
+import com.nawabali.nawabali.repository.querydsl.post.PostDslRepositoryCustom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class) // mockito 사용
+class PostServiceTest {
+
+
+    @Mock   // mock 객체 생성
+    PostRepository postRepository;
+
+
+
+    @InjectMocks    // @Mock 이 붙은 목객체를 이 어노테이션이 붙은 객체에 주입할 수 있음
+    private PostService postService;
+
+
+    @Test
+    @DisplayName("최신순으로 모든 게시물 불러오기")
+    void getPostsByLatest() {
+
+    }
+
+
+    @Test
+    @DisplayName("상세 게시물 불러오기")
+    void getPost() {
+    }
+
+    @Test
+    @DisplayName("카테고리 별 게시물 조회하기")
+    void getPostByCategory() {
+    }
+
+
+    @Test
+    @DisplayName("좋아요가 많은 순으로 게시물을 10개 조회")
+    void getPostByLike() {
+    }
+
+    @Test
+    @DisplayName("각 카테고리 별 기간기준 게시글이 가장 많았던 구를 출력")
+    void getDistrictByCategory() {
+
+        // given
+        Category testCategory = Category.PHOTOZONE;
+        Period testPeriod = Period.MONTH;
+
+        // when
+        PostDto.SortDistrictDto mockResponse = new PostDto.SortDistrictDto("SUNGBOOK", 3L);
+        when(postRepository.findDistrictByPost(testCategory, testPeriod)).thenReturn(mockResponse);
+
+        PostDto.SortDistrictDto result = postService.getDistrictByCategory(testCategory, testPeriod);
+        System.out.println("가장 많았던 구 = " + result.getDistrict());
+        System.out.println("게시물 개수 = " + result.getPostCount());
+
+        // then
+        assertNotNull(result);
+        assertEquals("SUNGBOOK", result.getDistrict(),"테스트 미통과");
+        assertEquals(3L, result.getPostCount());
+
+    }
+
+    @Test
+    @DisplayName("구와 한달기준 각 카테고리의 게시글 개수 출력")
+    void getCategoryByPost() {
+
+        String testDistrict = "SUNGBOOK";
+        List<PostDto.SortCategoryDto> mockResponse = new ArrayList<>();
+        mockResponse.add(new PostDto.SortCategoryDto("SUNGBOOK", 3L));
+
+        when(postRepository.findCategoryByPost(testDistrict)).thenReturn(mockResponse);
+
+        List<PostDto.SortCategoryDto> result = postService.getCategoryByPost(testDistrict);
+        for (PostDto.SortCategoryDto sortCategoryDto : result) {
+            System.out.println("sortCategoryDto.getCategory() = " + sortCategoryDto.getCategory());
+            System.out.println("sortCategoryDto.getPostCount() = " + sortCategoryDto.getPostCount());
+            
+        }
+
+        assertNotNull(result);
+        System.out.println("result.size() = " + result.size());     //1
+        System.out.println("Category.values().length = " + Category.values().length);   //3
+        assertTrue(result.size() <= Category.values().length);
+        assertTrue(result.stream().anyMatch(r -> r.getCategory().equals("SUNGBOOK") && r.getPostCount() == 3L));
+    }
+}


### PR DESCRIPTION
### PR 내용
- GET[/posts](https://hhboard.shop/swagger-ui/index.html#/%EA%B2%8C%EC%8B%9C%EB%AC%BC%20API/getPostsByLatest) 최신 게시물 조회
- GET[/posts/{postId}](https://hhboard.shop/swagger-ui/index.html#/%EA%B2%8C%EC%8B%9C%EB%AC%BC%20API/getPost) 게시물 상세 조회
- GET[/posts/filtered](https://hhboard.shop/swagger-ui/index.html#/%EA%B2%8C%EC%8B%9C%EB%AC%BC%20API/getPostByFiltered) 게시물 카테고리 or 구 로 조회
- GET[/posts/top-like](https://hhboard.shop/swagger-ui/index.html#/%EA%B2%8C%EC%8B%9C%EB%AC%BC%20API/getPostByLike) 일주일 동안 좋아요 기준 상위 10개 게시물 조회
다음 API 요청시 가게 이름 및 도로명 주소 반환(request 에도 추가) 