### PR TITLE
회원 정보 조회 API 추가 및 닉네임 검색시 반환값추가

### DIFF
--- a/src/main/java/com/nawabali/nawabali/config/WebSecurityConfig.java
+++ b/src/main/java/com/nawabali/nawabali/config/WebSecurityConfig.java
@@ -96,27 +96,18 @@ public class WebSecurityConfig {
                 authorizeHttpRequests
 //                        .anyRequest().permitAll()
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                        .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
-                        .requestMatchers("/users/logout").permitAll()
-                        .requestMatchers("/main.html").permitAll() // 메인 html페이지 요청 허가
-                        .requestMatchers("/ping", "/profile").permitAll() // 항상 200 OK 반환하는 health check 전용 API
-                        .requestMatchers("/users/signup").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/users/login").permitAll()
-                        .requestMatchers("/posts").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 게시글 상세 조회 허가
-                        .requestMatchers("/users/test").permitAll()
-                        .requestMatchers("/users/test1").permitAll()
                         .requestMatchers("/api/user/kakao/callback").permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/swagger/**").permitAll()
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api-test").permitAll()
-                        .requestMatchers("/users/check-nickname").permitAll()
                         .requestMatchers("/email-verification").permitAll()
+                        .requestMatchers("/ping", "/profile").permitAll() // 항상 200 OK 반환하는 health check 전용 API
+                        .requestMatchers(
+                                "/users/logout","/users/signup","/users/check-nickname", "users/info").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/users/login").permitAll()
+                        .requestMatchers("/posts","/posts/district/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 게시글 상세 조회 허가
+                        .requestMatchers("/comments/check/posts/**").permitAll()
+                        .requestMatchers("/swagger/**","/swagger-ui/**","/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws-stomp/**").permitAll()
                         .requestMatchers("/chat/**").permitAll()
-                        .requestMatchers("/posts/district/*").permitAll()
-                        .requestMatchers("/comments/check/posts/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
     }
 
     @Operation(summary = "유저 정보 조회", description = "회원 정보 조회에 사용하는 API")
-    @GetMapping("/user-info")
+    @GetMapping("/info")
     public UserDto.UserInfoResponseDto getUserInfo(@RequestParam(name = "userId") Long userId) {
         return userService.getUserInfo(userId);
     }

--- a/src/main/java/com/nawabali/nawabali/controller/UserController.java
+++ b/src/main/java/com/nawabali/nawabali/controller/UserController.java
@@ -47,13 +47,19 @@ public class UserController {
         return userService.signup(requestDto);
     }
 
-    @Operation(summary = "회원 정보 조회", description = "회원 정보 조회에 사용하는 API")
+    @Operation(summary = "내 정보 조회", description = "내 정보 조회에 사용하는 API")
     @GetMapping("/my-info")
     public UserDto.UserInfoResponseDto getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails){
         return userService.getUserInfo(userDetails.getUser());
     }
 
-    @Operation(summary = "회원 정보 수정", description = "회원 정보 수정에 사용하는 API")
+    @Operation(summary = "유저 정보 조회", description = "회원 정보 조회에 사용하는 API")
+    @GetMapping("/user-info")
+    public UserDto.UserInfoResponseDto getUserInfo(@RequestParam(name = "userId") Long userId) {
+        return userService.getUserInfo(userId);
+    }
+
+    @Operation(summary = "회원 정보 수정", description = "내 정보 수정에 사용하는 API")
     @PatchMapping("/my-info")
     public UserDto.UserInfoResponseDto updateUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody UserDto.UserInfoRequestDto userInfoRequestDto){
         return userService.updateUserInfo(userDetails.getUser(), userInfoRequestDto);
@@ -86,7 +92,7 @@ public class UserController {
     {
         return userService.getMyPosts(userDetails.getUser(), pageable, category);
     }
-
+    @Operation(summary = "채팅 할 회원의 닉네임 검색", description = "회원의 닉네임을 검색하면 PK, 프로필, 지역, 등급 반환")
     @GetMapping("/search")
     public List<UserSearch> searchNickname(@RequestParam(name = "nickname", required = false) String nickname){
         return userService.searchNickname(nickname);

--- a/src/main/java/com/nawabali/nawabali/domain/elasticsearch/UserSearch.java
+++ b/src/main/java/com/nawabali/nawabali/domain/elasticsearch/UserSearch.java
@@ -22,11 +22,17 @@ public class UserSearch {
     private String nickname;
     @Field(type=FieldType.Text)
     private String imgUrl;
+    @Field(type = FieldType.Text)
+    private String rankName;
+    @Field(type = FieldType.Text)
+    private String district;
 
 
     public UserSearch(User user, String imgUrl) {
         this.id = user.getId().toString();
         this.nickname = user.getNickname();
         this.imgUrl = imgUrl;
+        this.rankName = user.getRank().getName();
+        this.district = user.getAddress().getDistrict();
     }
 }

--- a/src/main/java/com/nawabali/nawabali/dto/UserDto.java
+++ b/src/main/java/com/nawabali/nawabali/dto/UserDto.java
@@ -27,6 +27,7 @@ public class UserDto {
         String city;
         String district;
         String rankName;
+        int totalPostsCount;
         Long totalLikesCount;
         Long totalLocalLikesCount;
         String profileImageUrl;
@@ -41,18 +42,6 @@ public class UserDto {
             this.district = user.getAddress().getDistrict();
             this.rankName = user.getRank().name();
             this.profileImageUrl = user.getProfileImage().getImgUrl();
-        }
-
-        public UserInfoResponseDto(User user, Long needPosts, Long needLikes) {
-            this.id = user.getId();
-            this.email = user.getEmail();
-            this.nickname = user.getNickname();
-            this.city = user.getAddress().getCity();
-            this.district = user.getAddress().getDistrict();
-            this.rankName = user.getRank().name();
-            this.profileImageUrl = user.getProfileImage().getImgUrl();
-            this.needPosts = needPosts;
-            this.needLikes = needLikes;
         }
     }
 

--- a/src/main/java/com/nawabali/nawabali/service/UserService.java
+++ b/src/main/java/com/nawabali/nawabali/service/UserService.java
@@ -130,12 +130,13 @@ public class UserService {
         List<Long> postIds = getMyPostIds(userId);
         System.out.println("postIds = " + postIds);
 
-        // 작성된 postID로 좋아요, 로컬좋아요 카운팅
-        Long totalLikeCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LIKE);
-        Long totalLocalLikeCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LOCAL_LIKE);
+        // 작성된 postID로  게시글, 좋아요, 로컬좋아요 카운팅
+        int totalPostsCount = postIds.size();
+        Long totalLikesCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LIKE);
+        Long totalLocalLikesCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LOCAL_LIKE);
 
-        Long needPosts = Math.max(existUser.getRank().getNeedPosts() - postIds.size(), 0L);
-        Long needLikes = Math.max(existUser.getRank().getNeedLikes() - totalLikeCount, 0L);
+        Long needPosts = Math.max(existUser.getRank().getNeedPosts() - totalPostsCount, 0L);
+        Long needLikes = Math.max(existUser.getRank().getNeedLikes() - totalLikesCount, 0L);
 
         postIds = null;
 
@@ -146,8 +147,9 @@ public class UserService {
                 .rankName(existUser.getRank().getName())
                 .city(existUser.getAddress().getCity())
                 .district(existUser.getAddress().getDistrict())
-                .totalLikesCount(totalLikeCount)
-                .totalLocalLikesCount(totalLocalLikeCount)
+                .totalPostsCount(totalPostsCount)
+                .totalLikesCount(totalLikesCount)
+                .totalLocalLikesCount(totalLocalLikesCount)
                 .profileImageUrl(existUser.getProfileImage().getImgUrl())
                 .needPosts(needPosts)
                 .needLikes(needLikes)
@@ -161,12 +163,13 @@ public class UserService {
         List<Long> postIds = getMyPostIds(userId);
         System.out.println("postIds = " + postIds);
 
-        // 작성된 postID로 좋아요, 로컬좋아요 카운팅
-        Long totalLikeCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LIKE);
-        Long totalLocalLikeCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LOCAL_LIKE);
+        // 작성된 postID로  게시글, 좋아요, 로컬좋아요 카운팅
+        int totalPostsCount = postIds.size();
+        Long totalLikesCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LIKE);
+        Long totalLocalLikesCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LOCAL_LIKE);
 
-        Long needPosts = Math.max(existUser.getRank().getNeedPosts() - postIds.size(), 0L);
-        Long needLikes = Math.max(existUser.getRank().getNeedLikes() - totalLikeCount, 0L);
+        Long needPosts = Math.max(existUser.getRank().getNeedPosts() - totalPostsCount, 0L);
+        Long needLikes = Math.max(existUser.getRank().getNeedLikes() - totalLikesCount, 0L);
 
         postIds = null;
 
@@ -177,8 +180,9 @@ public class UserService {
                 .rankName(existUser.getRank().getName())
                 .city(existUser.getAddress().getCity())
                 .district(existUser.getAddress().getDistrict())
-                .totalLikesCount(totalLikeCount)
-                .totalLocalLikesCount(totalLocalLikeCount)
+                .totalPostsCount(totalPostsCount)
+                .totalLikesCount(totalLikesCount)
+                .totalLocalLikesCount(totalLocalLikesCount)
                 .profileImageUrl(existUser.getProfileImage().getImgUrl())
                 .needPosts(needPosts)
                 .needLikes(needLikes)

--- a/src/main/java/com/nawabali/nawabali/service/UserService.java
+++ b/src/main/java/com/nawabali/nawabali/service/UserService.java
@@ -1,6 +1,5 @@
 package com.nawabali.nawabali.service;
 
-import co.elastic.clients.elasticsearch._types.query_dsl.PercolateQuery;
 import com.nawabali.nawabali.constant.*;
 import com.nawabali.nawabali.domain.User;
 import com.nawabali.nawabali.domain.elasticsearch.UserSearch;
@@ -17,9 +16,6 @@ import com.nawabali.nawabali.repository.ProfileImageRepository;
 import com.nawabali.nawabali.repository.UserRepository;
 import com.nawabali.nawabali.repository.elasticsearch.UserSearchRepository;
 import com.nawabali.nawabali.security.Jwt.JwtUtil;
-import io.jsonwebtoken.Jwt;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/nawabali/nawabali/service/UserService.java
+++ b/src/main/java/com/nawabali/nawabali/service/UserService.java
@@ -154,6 +154,37 @@ public class UserService {
                 .build();
     }
 
+    public UserDto.UserInfoResponseDto getUserInfo(Long userId){
+        User existUser = getUserId(userId);
+
+        // 유저 아이디로 작성된 postID 모두 검색
+        List<Long> postIds = getMyPostIds(userId);
+        System.out.println("postIds = " + postIds);
+
+        // 작성된 postID로 좋아요, 로컬좋아요 카운팅
+        Long totalLikeCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LIKE);
+        Long totalLocalLikeCount = getMyTotalLikesCount(postIds, LikeCategoryEnum.LOCAL_LIKE);
+
+        Long needPosts = Math.max(existUser.getRank().getNeedPosts() - postIds.size(), 0L);
+        Long needLikes = Math.max(existUser.getRank().getNeedLikes() - totalLikeCount, 0L);
+
+        postIds = null;
+
+        return UserDto.UserInfoResponseDto.builder()
+                .id(existUser.getId())
+                .email(existUser.getEmail())
+                .nickname(existUser.getNickname())
+                .rankName(existUser.getRank().getName())
+                .city(existUser.getAddress().getCity())
+                .district(existUser.getAddress().getDistrict())
+                .totalLikesCount(totalLikeCount)
+                .totalLocalLikesCount(totalLocalLikeCount)
+                .profileImageUrl(existUser.getProfileImage().getImgUrl())
+                .needPosts(needPosts)
+                .needLikes(needLikes)
+                .build();
+    }
+
     @Transactional
     public UserDto.UserInfoResponseDto updateUserInfo(User user, UserDto.UserInfoRequestDto requestDto) {
         User existUser = getUserId(user.getId());


### PR DESCRIPTION
나래님 요청으로 API추가 및 엘라스틱 엔티티 수정 했습니다.
-다른 회원의 정보를 조회할 수 있는 API 추가 했습니다. 
-닉네임 검색시 반환값에 사는 지역(=구) 와 등급을 추가했습니다.
-WebSecuriyConfig 의 PermitURL이 복잡하여 컨트롤러 별로 묶었습니다.
-회원 정보 조회시 총 게시글의 수도 반환값에 추가했습니다.

**회원 정보 조회**
![스크린샷 2024-04-24 235147](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/e87f35b3-dbb6-40a6-a6e2-30d5c6463d4a)

**닉네임 검색**
![스크린샷 2024-04-24 232646](https://github.com/Nawabali-project/Nawabali-BE/assets/119021313/373f0c5c-a975-4199-8ede-ba502a767ab7)
